### PR TITLE
README.md update

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Example usage:
 import toml
 
 with open("conf.toml") as conffile:
-     config = toml.dumps(conffile.read())
+     config = toml.loads(conffile.read())
 # do stuff with config here
 . . .
 ```


### PR DESCRIPTION
As it is now the example in README.md doesn't work:

```
Traceback (most recent call last):
  File "./x.py", line 7, in <module>
    config = toml.dumps(conffile.read())
  File "/usr/local/lib/python2.7/dist-packages/toml.py", line 209, in dumps
    addtoretval, sections = dump_sections(o)
  File "/usr/local/lib/python2.7/dist-packages/toml.py", line 227, in dump_sections
    if not isinstance(o[section], dict):
TypeError: string indices must be integers, not str
```

It should say `loads` instead of `dumps`. Caused me some confusion.
