### PR TITLE
Update toml.py

### DIFF
--- a/toml.py
+++ b/toml.py
@@ -104,7 +104,7 @@ def loads(s):
         raise Exception("What exactly are you trying to pull?")
     for line in s:
         line = line.strip()
-        if line == "":
+        if line == "" or line == "#":
             continue
         if line[0] == '[':
             arrayoftables = False


### PR DESCRIPTION
Currently toml.py will fail to parse lines like:
# This is a comment. You can use foo = 'bar' on a line.

because it will be parsed as a value due to the '=', and not ignored as a comment.
