### PR TITLE
Fix issue in nested objects

### DIFF
--- a/toml.py
+++ b/toml.py
@@ -140,7 +140,7 @@ def loads(s):
                 except TypeError:
                     if i != len(groups) - 1:
                         implicitgroups.append(group)
-                    currentlevel = currentlevel[0]
+                    currentlevel = currentlevel[-1]
                     if arrayoftables:
                         currentlevel[group] = [{}]
                     else:


### PR DESCRIPTION
Make sure we get the last object back when adding to it

```
[[actions]]
name = "test"
[actions.data]
myname = "test"

[[actions]]
name = "test2"
[actions.data]
myname = "test2"

[[actions]]
name = "test3"
[actions.data]
myname = "test3"
```

Make this structure pass correctly now correctly results into

```
{'actions': [{'data': {'myname': 'test'}, 'name': 'test'},
  {'data': {'myname': 'test2'}, 'name': 'test2'},
  {'data': {'myname': 'test3'}, 'name': 'test3'}]}
```

instead of

```
{'actions': [{'data': {'myname': 'test3'}, 'name': 'test'},
  {'name': 'test2'},
  {'name': 'test3'}]}
```
