### PR TITLE
Make toml.py accept spaces in table names.

### DIFF
--- a/toml.py
+++ b/toml.py
@@ -85,13 +85,12 @@ def loads(s):
             if sl[i] == ']' and not openstring:
                 if keygroup:
                     keygroup = False
-                    intablename = False
                 elif arrayoftables:
                     if sl[i-1] == ']':
                         arrayoftables = False
-                        intablename = False
-                elif not intablename:
+                elif not intablename and sl[i-1] != ']':
                     openarr -= 1
+                intablename = False
             if sl[i] == '\n':
                 if openstring:
                     raise Exception("Unbalanced quotes")


### PR DESCRIPTION
toml.py currently accepts spaces in key names, but raises an `Exception` on
table names with spaces in them.  This had to do with the first half of
`loads()` replacing the newline after a space-containing table name with a
space, thinking it was in an open array.

So, this was ok:

```
>>> toml.loads('''\
... [a]
... x = 1
... ''')
{'a': {'x': 1}}
```

But this was not:

```
>>> toml.loads('''\
... [a b]
... x = 1
... ''')
Traceback (most recent call last):
  File "<stdin>", line 4, in <module>
  File "toml.py", line 117, in loads
    raise Exception("Key group not on a line by itself.")
Exception: Key group not on a line by itself.
```

Adding a flag to the tokenizing (?) portion of `loads()` to track when we are inside a table (or `arrayoftable` for that matter) seems to prevent [these lines](https://github.com/uiri/toml/blob/5ad4ccac3943a2522e92679a00cf8bcb0d1e1f8d/toml.py#L64-67) from causing `openarr` to decrement later (which results in the deletion of a newline).

This patch does not change any results from BurntSushi's test suite.
