### PR TITLE
load_value returns unicode instead str

### DIFF
--- a/toml.py
+++ b/toml.py
@@ -50,7 +50,7 @@ def loads(s):
         keyname = False
         delnum = 1
         for i in range(len(sl)):
-            if keyname and not openstring:                
+            if keyname and not openstring:
                 if sl[i] == '\n':
                     raise Exception("Key name found without value. Reached end of line.")
                 if sl[i] == '#':
@@ -377,11 +377,11 @@ def load_value(v):
                 v = re.sub("([^\\\\](\\\\\\\\)*)\\\\"+escapes[i], "\\1"+escapedchars[i], v)
         if v[1] == '"':
             v = v[2:-2]
-        return (v[1:-1], "str")
+        return (v[1:-1].decode("utf-8"), "str")
     elif v[0] == "'":
         if v[1] == "'":
             v = v[2:-2]
-        return (v[1:-1], "str")
+        return (v[1:-1].decode("utf-8"), "str")
     elif v[0] == '[':
         return (load_array(v), "array")
     elif len(v) == 20 and v[-1] == 'Z':


### PR DESCRIPTION
I've changed load_value function ito return unicode instead of str. It is important when we use non ASCII characters.

Now we have:
>>> print toml.loads('key = "val"')
{'x': u'a'}

Before my change we had:
>>> print toml.loads('key = "val"')
{'x': 'a'}
