### PR TITLE
Fix endless loop

### DIFF
--- a/toml.py
+++ b/toml.py
@@ -253,8 +253,7 @@ def loads(s, _dict=dict):
                         datetime.datetime.strptime(pair[-1], "%Y-%m-%dT%H:%M:%SZ")
                         break
                     except ValueError:
-                        i += 1
-                        pair = line.split('=', i)
+                        raise Exception("What's the datatype of '"+pair[-1]+"'?")
             newpair = []
             newpair.append('='.join(pair[:-1]))
             newpair.append(pair[-1])

--- a/toml.py
+++ b/toml.py
@@ -238,9 +238,7 @@ def loads(s, _dict=dict):
                     except KeyError:
                         pass
         elif "=" in line:
-            i = 1
-            pair = line.split('=', i)
-            l = len(line)
+            pair = line.split('=', 1)
             while pair[-1][0] != ' ' and pair[-1][0] != '\t' and \
                     pair[-1][0] != "'" and pair[-1][0] != '"' and \
                     pair[-1][0] != '[' and pair[-1] != 'true' and \


### PR DESCRIPTION
The following toml file would cause an endless loop (somevalue is not in quotes):
```toml
somekey=somevalue
```
Because more than one '=' is not specified in [spec](https://github.com/toml-lang/toml),
`line.split()` should only be called with *count=1*.
--> You don't need to increase *count* infinitely if data type is unknown.
