### PR TITLE
Recognize both str and bytes as string in Python 3

### DIFF
--- a/toml.py
+++ b/toml.py
@@ -20,7 +20,7 @@ try:
 except NameError:
     unicode = str
     _range = range
-    basestring = str
+    basestring = (str, bytes)
     unichr = chr
 
 def load(f, _dict=dict):


### PR DESCRIPTION
With this pull request, all the places that only accept `str` now will also accept `bytes`, which I believe is the correct thing to do.