### PR TITLE
Fixes for weird numbers

### DIFF
--- a/toml.py
+++ b/toml.py
@@ -509,6 +509,7 @@ def _load_value(v):
             v = float(v)
             itype = "float"
         else:
+            v = v.replace('_', '')
             v = int(v)
         if neg:
             return (0 - v, itype)

--- a/toml.py
+++ b/toml.py
@@ -501,15 +501,17 @@ def _load_value(v):
         if v[0] == '-':
             neg = True
             v = v[1:]
-        if '.' in v or 'e' in v:
-            if v.split('.', 1)[1] == '':
+        elif v[0] == '+':
+            v = v[1:]
+        v = v.replace('_', '')
+        if '.' in v or 'e' in v or 'E' in v:
+            if '.' in v and v.split('.', 1)[1] == '':
                 raise TomlDecodeError("This float is missing digits after the point")
             if v[0] not in '0123456789':
                 raise TomlDecodeError("This float doesn't have a leading digit")
             v = float(v)
             itype = "float"
         else:
-            v = v.replace('_', '')
             v = int(v)
         if neg:
             return (0 - v, itype)


### PR DESCRIPTION
Fix some issues with parsing weird numbers (found in the example)

 * `1_234_567` == `1234567`
 * `2E2` == `200.0`
 * `9_224_617.445_991_228_313` == `9224617.445991228313`

Now, travis should be all happy.