### PR TITLE
Added minus sign to allow negative numbers in inline dicts

### DIFF
--- a/toml.py
+++ b/toml.py
@@ -296,7 +296,7 @@ def _load_inline_object(line, currentlevel, multikey=False, multibackslash=False
         _, value = candidate_group.split('=', 1)
         value = value.strip()
         if (value[0] == value[-1] and value[0] in ('"', "'")) or \
-                value[0] in '0123456789' or \
+                value[0] in '-0123456789' or \
                 value in ('true', 'false') or \
                 value[0] == "[" and value[-1] == "]":
             groups.append(candidate_group)


### PR DESCRIPTION
Trivial dict like this would fail to parse.

```toml
test = {x = -3}
```