### PR TITLE
add preserve flag to dumps to preserve inline table syntax

### DIFF
--- a/toml.py
+++ b/toml.py
@@ -711,14 +711,10 @@ def _dump_inline_table(section):
         for k, v in section.items():
             val = _dump_inline_table(v)
             val_list.append(k + " = " + val)
-        retval += "{" + ", ".join(val_list) + "}\n"
-        return retval
-    elif isinstance(section, list):
-        val_list = [_dump_inline_table(i) for i in section]
-        retval += "[" + ", ".join(val_list) + "]"
+        retval += "{ " + ", ".join(val_list) + " }\n"
         return retval
     else:
-        return "\"" + section + "\""
+        return str(_dump_value(section))
 
 def _dump_value(v):
     if isinstance(v, list):

--- a/toml.py
+++ b/toml.py
@@ -25,6 +25,10 @@ class TomlTz(datetime.tzinfo):
     def dst(self, dt):
         return datetime.timedelta(0)
 
+class InlineTableDict(dict):
+    def __init__(self, *args):
+        dict.__init__(self, args)
+
 try:
     _range = xrange
 except NameError:
@@ -520,7 +524,7 @@ def _load_value(v, strictly_valid=True):
     elif v[0] == '[':
         return (_load_array(v), "array")
     elif v[0] == '{':
-        inline_object = {}
+        inline_object = InlineTableDict()
         _load_inline_object(v, inline_object)
         return (inline_object, "inline_object")
     else:
@@ -692,7 +696,7 @@ def _dump_sections(o, sup, preserve=False):
                 if o[section] is not None:
                     retstr += (qsection + " = " +
                                str(_dump_value(o[section])) + '\n')
-        elif preserve:
+        elif preserve and isinstance(o[section], InlineTableDict):
             retstr += (section + " = " + _dump_inline_table(o[section]))
         else:
             retdict[qsection] = o[section]

--- a/toml.py
+++ b/toml.py
@@ -628,7 +628,7 @@ def dump(o, f):
     f.write(d)
     return d
 
-def dumps(o):
+def dumps(o, preserve=False):
     """Returns a string containing the toml corresponding to o, a dictionary"""
     retval = ""
     addtoretval, sections = _dump_sections(o, "")
@@ -636,7 +636,8 @@ def dumps(o):
     while sections != {}:
         newsections = {}
         for section in sections:
-            addtoretval, addtosections = _dump_sections(sections[section], section)
+            addtoretval, addtosections = _dump_sections(sections[section],
+                                                        section, preserve)
             if addtoretval:
                 if retval and retval[-2:] != "\n\n":
                     retval += "\n"
@@ -647,7 +648,7 @@ def dumps(o):
         sections = newsections
     return retval
 
-def _dump_sections(o, sup):
+def _dump_sections(o, sup, preserve=False):
     retstr = ""
     if sup != "" and sup[-1] != ".":
         sup += '.'
@@ -691,10 +692,33 @@ def _dump_sections(o, sup):
                 if o[section] is not None:
                     retstr += (qsection + " = " +
                                str(_dump_value(o[section])) + '\n')
+        elif preserve:
+            retstr += (section + " = " + _dump_inline_table(o[section]))
         else:
             retdict[qsection] = o[section]
     retstr += arraystr
     return (retstr, retdict)
+
+def _dump_inline_table(section):
+    """Preserve inline table in its compact syntax instead of expanding
+    into subsection.
+
+    https://github.com/toml-lang/toml#user-content-inline-table
+    """
+    retval = ""
+    if isinstance(section, dict):
+        val_list = []
+        for k, v in section.items():
+            val = _dump_inline_table(v)
+            val_list.append(k + " = " + val)
+        retval += "{" + ", ".join(val_list) + "}\n"
+        return retval
+    elif isinstance(section, list):
+        val_list = [_dump_inline_table(i) for i in section]
+        retval += "[" + ", ".join(val_list) + "]"
+        return retval
+    else:
+        return "\"" + section + "\""
 
 def _dump_value(v):
     if isinstance(v, list):


### PR DESCRIPTION
This is a patch to address issue #74.

This library will currently ingest TOML in the format below with `loads`:

```
[[source]]
url = "https://pypi.python.org/simple"
verify_ssl = true

[dev-packages]
pytest = "*"

[packages]
codecov = "*"
pytest-httpbin = {extras = ["Flask", "fast"]}
sphinx = "==1.4.8"
```

However, when you go to save this TOML back to the file, it will rewrite the contents as:

```
[[source]]
url = "https://pypi.python.org/simple"
verify_ssl = true

[dev-packages]
pytest = "*"

[packages]
codecov = "*"
sphinx = "==1.4.8"

[packages.pytest-httpbin]
extras = [ "Flask", "fast",]
```


While this is valid syntax, it would be nice to preserve the more compact inline table syntax when present. This patch adds a flag `preserve` to `dumps` which will write the contents in inline table syntax back out to the file, rather than expanding it.

Some outstanding notes:
* I'd be happy to add tests for this, but didn't see a way to do it with the go test library
* I only added the flag to `dumps` and `_dump_section` but not `dump`. I could see it being useful there too but didn't want to make more changes than needed. Let me know if you'd like to see it there as well.