### PR TITLE
Make InlineTableDict inherit from OrderedDict

### DIFF
--- a/toml.py
+++ b/toml.py
@@ -3,6 +3,7 @@
 import re
 import datetime
 import io
+from collections import OrderedDict
 
 class TomlDecodeError(Exception):
     pass
@@ -27,9 +28,8 @@ class TomlTz(datetime.tzinfo):
     def dst(self, dt):
         return datetime.timedelta(0)
 
-class InlineTableDict(dict):
-    def __init__(self, *args):
-        dict.__init__(self, args)
+class InlineTableDict(OrderedDict):
+    """Sentinel subclass of dict for inline tables."""
 
 try:
     _range = xrange


### PR DESCRIPTION
References my review comment from #75.

I first looked at creating an analog to `_dict`, that I was thinking to call `_InlineTableDict`. However, while I was doing that it became apparent that it would end up as a pretty infectious change, which would require change to at around 4 method signatures and 8 call sites. `_dict` is only a parameter for `load` and `loads`, so that just didn't seem like the best approach.

My thinking with this pull request is that there is a complexity trade-off from choosing to make `InlineTableDict` overridable, and that's it's not worth what it costs. `OrderedDict` has good performance characteristics, and Python 3.6 has even made the default dict order-preserving. Combined with the relatively limited use we'd expect to see with `InlineTableDict` over our standard use of `dict`, it seemed to me to be a reasonable choice.

If you disagree with my assessment, I'm willing to open another pull request with the required changes to add an `_InlineTableDict` parameter to `load` and `loads` for comparison.