### PR TITLE
Do not override dict __init__ for InlineTableDict

### DIFF
--- a/toml.py
+++ b/toml.py
@@ -28,8 +28,7 @@ class TomlTz(datetime.tzinfo):
         return datetime.timedelta(0)
 
 class InlineTableDict(dict):
-    def __init__(self, *args):
-        dict.__init__(self, args)
+    """Sentinel subclass of dict for inline tables."""
 
 try:
     _range = xrange


### PR DESCRIPTION
As promised in #86, I've split this uncontroversial change into it's own pull request.