### PR TITLE
Enable support for toml.__version__

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
+import toml
 from distutils.core import setup
 
 with open("README.rst") as readmefile:
     readme = readmefile.read()
 setup(name='toml',
-      version='0.9.2',
+      version=toml.__version__,
       description="Python Library for Tom's Obvious, Minimal Language",
       author="Uiri Noyb",
       author_email="uiri@xqz.ca",

--- a/toml.py
+++ b/toml.py
@@ -4,6 +4,8 @@ import re
 import datetime
 import io
 
+__version__ = "0.9.2"
+
 class TomlDecodeError(Exception):
     pass
 

--- a/toml.py
+++ b/toml.py
@@ -5,6 +5,7 @@ import datetime
 import io
 
 __version__ = "0.9.2"
+__spec__ = "0.4.0"
 
 class TomlDecodeError(Exception):
     pass


### PR DESCRIPTION
Sometimes it can be useful to reference what version of `toml` one is using, especially as the spec continues to change.

```python
>>> import toml
>>> print(toml.__version__)
'0.9.2'
```