### PR TITLE
Feature: Let load() handle non-existing files in list.

### DIFF
--- a/toml.py
+++ b/toml.py
@@ -64,9 +64,10 @@ def load(f, _dict=dict):
         Parsed toml file represented as a dictionary
 
     Raises:
-        FileNotFoundError -- When array with no existing file path(s) is passed
         TypeError -- When f is invalid type
         TomlDecodeError: Error while decoding toml
+        IOError -- When array with zero valid (existing) file paths is passed (Python 2)
+        FileNotFoundError -- When array with zero valid (existing) file paths is passed (Python 3)
     """
 
     if isinstance(f, basestring):
@@ -79,7 +80,11 @@ def load(f, _dict=dict):
             error_msg = "Load expects a list to contain filenames only."
             error_msg += linesep
             error_msg += "The list needs to contain the path of at least one existing file."
-            raise FileNotFoundError(error_msg)
+            try:
+                raise FileNotFoundError(error_msg)
+            except NameError:
+                # Program executed with Python 2, not Python 3:
+                raise IOError(error_msg)
         d = _dict()
         for l in f:
             d.update(load(l))

--- a/toml.py
+++ b/toml.py
@@ -68,9 +68,17 @@ def load(f, _dict=dict):
         with io.open(f, encoding='utf-8') as ffile:
             return loads(ffile.read(), _dict)
     elif isinstance(f, list):
-        for l in f:
-            if not isinstance(l, basestring):
-                raise TypeError("Load expects a list to contain filenames only")
+        from os import path as op
+        # Should we remove erroneous entries?
+        #   Say, permit non-existing files?
+        # Then comment in below line:
+        # f = [path for path in f if op.exist(path)]
+        if not any(op.exist(l) for l in f):
+            from os import linesep
+            error_msg = "Load expects a list to contain filenames only."
+            error_msg += linesep
+            error_msg += "The list needs to contain the path of at least one existing file."
+            raise TypeError(error_msg)
         d = _dict()
         for l in f:
             d.update(load(l))

--- a/toml.py
+++ b/toml.py
@@ -1,8 +1,10 @@
 # This software is released under the MIT license
 
 import re
-import datetime
 import io
+import datetime
+from os import linesep
+
 
 __version__ = "0.9.2"
 __spec__ = "0.4.0"
@@ -62,7 +64,7 @@ def load(f, _dict=dict):
         Parsed toml file represented as a dictionary
 
     Raises:
-        TypeError -- When array of non-strings is passed
+        FileNotFoundError -- When array with no existing file path(s) is passed
         TypeError -- When f is invalid type
         TomlDecodeError: Error while decoding toml
     """
@@ -72,16 +74,12 @@ def load(f, _dict=dict):
             return loads(ffile.read(), _dict)
     elif isinstance(f, list):
         from os import path as op
-        # Should we remove erroneous entries?
-        #   Say, permit non-existing files?
-        # Then comment in below line:
-        # f = [path for path in f if op.exist(path)]
-        if not any(op.exist(l) for l in f):
-            from os import linesep
+        f = [path for path in f if op.exists(path)]
+        if not f:
             error_msg = "Load expects a list to contain filenames only."
             error_msg += linesep
             error_msg += "The list needs to contain the path of at least one existing file."
-            raise TypeError(error_msg)
+            raise FileNotFoundError(error_msg)
         d = _dict()
         for l in f:
             d.update(load(l))


### PR DESCRIPTION
As long as there's at least _one_ existing file in the list given.
To permit things like the examples listed here: https://github.com/uiri/toml/issues/9#issuecomment-17939193

Hopefully the result becomes either what's in `config.ini` or `config_dev.ini` if either's opposite is non-existent on the filesystem.