### PR TITLE
Pep8ify the source code

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,42 @@
+[flake8]
+exclude =
+    # Do not track .git dir
+    .git,
+    # Do not track virtualenv dir
+    venv,
+    # Do not track pycache dirs
+    __pycache__,
+
+# A nested complexity of more than 5 is a sign that we should perhaps
+#  flatten out the code's cyclomatic complexity...
+max-complexity = 5
+
+# All modern monitors should at least handle 120 chars in a row without wrapping
+max-line-length = 120
+
+# Default errors ++: http://pep8.readthedocs.io/en/release-1.7.x/intro.html
+#   (Contains E/W error codes, at least some)
+#  DXYZ error codes listed here: http://pep257.readthedocs.io/en/latest/error_codes.html
+ignore =
+    D204,   # Not Default
+    E121,
+    E126,
+    E133,
+    E226,
+    W503,
+
+# Which errors to enable (display)
+#select-errors =
+    E,
+    F,
+    W,
+    C
+
+# Ignore '#noqa' pragmas
+disable-noqa = True
+
+# Output config:
+show-source = True
+statistics = True
+tee = True
+output-file = .flake8.log

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+appdirs==1.4.3
+configparser==3.5.0
+enum34==1.1.6
+flake8==3.3.0
+mccabe==0.6.1
+packaging==16.8
+pycodestyle==2.3.1
+pyflakes==1.5.0
+pyparsing==2.2.0
+six==1.10.0

--- a/toml.py
+++ b/toml.py
@@ -1,5 +1,7 @@
-# This software is released under the MIT license
+"""Python module which parses and emits TOML.
 
+Released under the MIT license.
+"""
 import re
 import datetime
 import io
@@ -7,11 +9,13 @@ import io
 __version__ = "0.9.2"
 __spec__ = "0.4.0"
 
+
 class TomlDecodeError(Exception):
+    """Base toml Exception / Error."""
     pass
 
-class TomlTz(datetime.tzinfo):
 
+class TomlTz(datetime.tzinfo):
     def __init__(self, toml_offset):
         if toml_offset == "Z":
             self._raw_offset = "+00:00"
@@ -22,7 +26,7 @@ class TomlTz(datetime.tzinfo):
         self._minutes = int(self._raw_offset[4:6])
 
     def tzname(self, dt):
-        return "UTC"+self._raw_offset
+        return "UTC" + self._raw_offset
 
     def utcoffset(self, dt):
         return self._sign * datetime.timedelta(hours=self._hours, minutes=self._minutes)
@@ -30,8 +34,10 @@ class TomlTz(datetime.tzinfo):
     def dst(self, dt):
         return datetime.timedelta(0)
 
+
 class InlineTableDict(object):
     """Sentinel subclass of dict for inline tables."""
+
 
 def _get_empty_inline_table(_dict):
     class DynamicInlineTableDict(_dict, InlineTableDict):
@@ -42,6 +48,7 @@ def _get_empty_inline_table(_dict):
 
     return DynamicInlineTableDict()
 
+
 try:
     _range = xrange
 except NameError:
@@ -49,6 +56,7 @@ except NameError:
     _range = range
     basestring = str
     unichr = chr
+
 
 def load(f, _dict=dict):
     """Parses named file or files as toml and returns a dictionary
@@ -83,7 +91,9 @@ def load(f, _dict=dict):
     else:
         raise TypeError("You can only load a file descriptor, filename or list")
 
+
 _groupname_re = re.compile(r'^[A-Za-z0-9_-]+$')
+
 
 def loads(s, _dict=dict):
     """Parses string as toml
@@ -119,7 +129,7 @@ def loads(s, _dict=dict):
     keygroup = False
     keyname = 0
     for i, item in enumerate(sl):
-        if item == '\r' and sl[i+1] == '\n':
+        if item == '\r' and sl[i + 1] == '\n':
             sl[i] = ' '
             continue
         if keyname:
@@ -142,11 +152,11 @@ def loads(s, _dict=dict):
             if item == '=':
                 keyname = 0
             else:
-                raise TomlDecodeError("Found invalid character in key name: '"+item+"'. Try quoting the key name.")
+                raise TomlDecodeError("Found invalid character in key name: '" + item + "'. Try quoting the key name.")
         if item == "'" and openstrchar != '"':
             k = 1
             try:
-                while sl[i-k] == "'":
+                while sl[i - k] == "'":
                     k += 1
                     if k == 3:
                         break
@@ -166,12 +176,12 @@ def loads(s, _dict=dict):
             k = 1
             tripquote = False
             try:
-                while sl[i-k] == '"':
+                while sl[i - k] == '"':
                     k += 1
                     if k == 3:
                         tripquote = True
                         break
-                while sl[i-k] == '\\':
+                while sl[i - k] == '\\':
                     oddbackslash = not oddbackslash
                     k += 1
             except IndexError:
@@ -198,7 +208,7 @@ def loads(s, _dict=dict):
         if item == '[' and not openstring and not keygroup and \
                 not arrayoftables:
             if beginline:
-                if sl[i+1] == '[':
+                if sl[i + 1] == '[':
                     arrayoftables = True
                 else:
                     keygroup = True
@@ -208,7 +218,7 @@ def loads(s, _dict=dict):
             if keygroup:
                 keygroup = False
             elif arrayoftables:
-                if sl[i-1] == ']':
+                if sl[i - 1] == ']':
                     arrayoftables = False
             else:
                 openarr -= 1
@@ -216,10 +226,10 @@ def loads(s, _dict=dict):
             if openstring or multilinestr:
                 if not multilinestr:
                     raise TomlDecodeError("Unbalanced quotes")
-                if (sl[i-1] == "'" or sl[i-1] == '"') and sl[i-2] == sl[i-1]:
-                    sl[i] = sl[i-1]
-                    if sl[i-3] == sl[i-1]:
-                        sl[i-3] = ' '
+                if (sl[i - 1] == "'" or sl[i - 1] == '"') and sl[i - 2] == sl[i - 1]:
+                    sl[i] = sl[i - 1]
+                    if sl[i - 3] == sl[i - 1]:
+                        sl[i - 3] = ' '
             elif openarr:
                 sl[i] = ' '
             else:
@@ -253,7 +263,7 @@ def loads(s, _dict=dict):
                 multikey = None
                 multilinestr = ""
             else:
-                k = len(multilinestr) -1
+                k = len(multilinestr) - 1
                 while k > -1 and multilinestr[k] == '\\':
                     multibackslash = not multibackslash
                     k -= 1
@@ -277,15 +287,15 @@ def loads(s, _dict=dict):
                 groups[i] = groups[i].strip()
                 if groups[i][0] == '"' or groups[i][0] == "'":
                     groupstr = groups[i]
-                    j = i+1
+                    j = i + 1
                     while not groupstr[0] == groupstr[-1]:
                         j += 1
                         groupstr = '.'.join(groups[i:j])
                     groups[i] = groupstr[1:-1]
-                    groups[i+1:j] = []
+                    groups[i + 1:j] = []
                 else:
                     if not _groupname_re.match(groups[i]):
-                        raise TomlDecodeError("Invalid group name '"+groups[i]+"'. Try quoting it.")
+                        raise TomlDecodeError("Invalid group name '" + groups[i] + "'. Try quoting it.")
                 i += 1
             currentlevel = retval
             for i in _range(len(groups)):
@@ -302,7 +312,7 @@ def loads(s, _dict=dict):
                         elif arrayoftables:
                             currentlevel[group].append(_dict())
                         else:
-                            raise TomlDecodeError("What? "+group+" already exists?"+str(currentlevel))
+                            raise TomlDecodeError("What? " + group + " already exists?" + str(currentlevel))
                 except TypeError:
                     if i != len(groups) - 1:
                         implicitgroups.append(group)
@@ -335,6 +345,7 @@ def loads(s, _dict=dict):
                 multikey, multilinestr, multibackslash = ret
     return retval
 
+
 def _load_inline_object(line, currentlevel, _dict, multikey=False, multibackslash=False):
     candidate_groups = line[1:-1].split(",")
     groups = []
@@ -359,8 +370,10 @@ def _load_inline_object(line, currentlevel, _dict, multikey=False, multibackslas
         if status is not None:
             break
 
+
 # Matches a TOML number, which allows underscores for readability
 _number_with_underscores = re.compile('([0-9])(_([0-9]))*')
+
 
 def _strictly_valid_num(n):
     n = n.strip()
@@ -383,6 +396,7 @@ def _strictly_valid_num(n):
     if '__' in n:
         return False
     return True
+
 
 def _load_line(line, currentlevel, _dict, multikey, multibackslash):
     i = 1
@@ -414,10 +428,10 @@ def _load_line(line, currentlevel, _dict, multikey, multibackslash):
         pair[0] = pair[0][1:-1]
     if len(pair[1]) > 2 and (pair[1][0] == '"' or pair[1][0] == "'") \
             and pair[1][1] == pair[1][0] and pair[1][2] == pair[1][0] \
-            and not (len(pair[1]) > 5 and pair[1][-1] == pair[1][0] and \
-                         pair[1][-2] == pair[1][0] and \
-                         pair[1][-3] == pair[1][0]):
-        k = len(pair[1]) -1
+            and not (len(pair[1]) > 5 and pair[1][-1] == pair[1][0] and
+                     pair[1][-2] == pair[1][0] and
+                     pair[1][-3] == pair[1][0]):
+        k = len(pair[1]) - 1
         while k > -1 and pair[1][k] == '\\':
             multibackslash = not multibackslash
             k -= 1
@@ -439,6 +453,7 @@ def _load_line(line, currentlevel, _dict, multikey, multibackslash):
     except:
         raise TomlDecodeError("Duplicate keys!")
 
+
 def _load_date(val):
     microsecond = 0
     tz = None
@@ -453,10 +468,14 @@ def _load_date(val):
     except ValueError:
         tz = None
     try:
-        d = datetime.datetime(int(val[:4]), int(val[5:7]), int(val[8:10]), int(val[11:13]), int(val[14:16]), int(val[17:19]), microsecond, tz)
+        d = datetime.datetime(
+            int(val[:4]), int(val[5:7]),
+            int(val[8:10]), int(val[11:13]),
+            int(val[14:16]), int(val[17:19]), microsecond, tz)
     except ValueError:
         return None
     return d
+
 
 def _load_unicode_escapes(v, hexbytes, prefix):
     hexchars = ['0', '1', '2', '3', '4', '5', '6', '7',
@@ -493,10 +512,12 @@ def _load_unicode_escapes(v, hexbytes, prefix):
         v += unicode(hx[len(hxb):])
     return v
 
+
 # Unescape TOML string values.
-_escapes = ['0', 'b', 'f', 'n', 'r', 't', '"'] # content after the \
-_escapedchars = ['\0', '\b', '\f', '\n', '\r', '\t', '\"'] # What it should be replaced by
-_escape_to_escapedchars = dict(zip(_escapes, _escapedchars)) # Used for substitution
+_escapes = ['0', 'b', 'f', 'n', 'r', 't', '"']  # content after the \
+_escapedchars = ['\0', '\b', '\f', '\n', '\r', '\t', '\"']  # What it should be replaced by
+_escape_to_escapedchars = dict(zip(_escapes, _escapedchars))    # Used for substitution
+
 
 def _unescape(v):
     """Unescape characters in a TOML string."""
@@ -506,9 +527,9 @@ def _unescape(v):
         if backslash:
             backslash = False
             if v[i] in _escapes:
-                v = v[:i-1] + _escape_to_escapedchars[v[i]] + v[i+1:]
+                v = v[:i - 1] + _escape_to_escapedchars[v[i]] + v[i + 1:]
             elif v[i] == '\\':
-                v = v[:i-1] + v[i:]
+                v = v[:i - 1] + v[i:]
             elif v[i] == 'u' or v[i] == 'U':
                 i += 1
             else:
@@ -518,6 +539,7 @@ def _unescape(v):
             backslash = True
         i += 1
     return v
+
 
 def _load_value(v, _dict, strictly_valid=True):
     if not v:
@@ -607,6 +629,7 @@ def _load_value(v, _dict, strictly_valid=True):
             return (0 - v, itype)
         return (v, itype)
 
+
 def _load_array(a, _dict):
     atype = None
     retval = []
@@ -646,12 +669,12 @@ def _load_array(a, _dict):
                 ab = a[b].strip()
                 while ab[-1] != ab[0] or (ab[0] == ab[1] == ab[2] and
                                           ab[-2] != ab[0] and ab[-3] != ab[0]):
-                    a[b] = a[b] + ',' + a[b+1]
+                    a[b] = a[b] + ',' + a[b + 1]
                     ab = a[b].strip()
                     if b < len(a) - 2:
-                        a = a[:b+1] + a[b+2:]
+                        a = a[:b + 1] + a[b + 2:]
                     else:
-                        a = a[:b+1]
+                        a = a[:b + 1]
                 b += 1
     else:
         al = list(a[1:-1])
@@ -665,7 +688,7 @@ def _load_array(a, _dict):
                 openarr -= 1
             elif al[i] == ',' and not openarr:
                 a.append(''.join(al[j:i]))
-                j = i+1
+                j = i + 1
         a.append(''.join(al[j:]))
     for i in _range(len(a)):
         a[i] = a[i].strip()
@@ -678,6 +701,7 @@ def _load_array(a, _dict):
                 atype = ntype
             retval.append(nval)
     return retval
+
 
 def dump(o, f):
     """Writes out dict as toml to a file
@@ -698,6 +722,7 @@ def dump(o, f):
     d = dumps(o)
     f.write(d)
     return d
+
 
 def dumps(o, preserve=False):
     """Stringifies input dict as toml
@@ -722,13 +747,14 @@ def dumps(o, preserve=False):
             if addtoretval or (not addtoretval and not addtosections):
                 if retval and retval[-2:] != "\n\n":
                     retval += "\n"
-                retval += "["+section+"]\n"
+                retval += "[" + section + "]\n"
                 if addtoretval:
                     retval += addtoretval
             for s in addtosections:
-                newsections[section+"."+s] = addtosections[s]
+                newsections[section + "." + s] = addtosections[s]
         sections = newsections
     return retval
+
 
 def _dump_sections(o, sup, preserve=False):
     retstr = ""
@@ -752,8 +778,8 @@ def _dump_sections(o, sup, preserve=False):
             if arrayoftables:
                 for a in o[section]:
                     arraytabstr = "\n"
-                    arraystr += "[["+sup+qsection+"]]\n"
-                    s, d = _dump_sections(a, sup+qsection)
+                    arraystr += "[[" + sup + qsection + "]]\n"
+                    s, d = _dump_sections(a, sup + qsection)
                     if s:
                         if s[0] == "[":
                             arraytabstr += s
@@ -762,12 +788,12 @@ def _dump_sections(o, sup, preserve=False):
                     while d != {}:
                         newd = {}
                         for dsec in d:
-                            s1, d1 = _dump_sections(d[dsec], sup+qsection+"."+dsec)
+                            s1, d1 = _dump_sections(d[dsec], sup + qsection + "." + dsec)
                             if s1:
-                                arraytabstr += "["+sup+qsection+"."+dsec+"]\n"
+                                arraytabstr += "[" + sup + qsection + "." + dsec + "]\n"
                                 arraytabstr += s1
                             for s1 in d1:
-                                newd[dsec+"."+s1] = d1[s1]
+                                newd[dsec + "." + s1] = d1[s1]
                         d = newd
                     arraystr += arraytabstr
             else:
@@ -780,6 +806,7 @@ def _dump_sections(o, sup, preserve=False):
             retdict[qsection] = o[section]
     retstr += arraystr
     return (retstr, retdict)
+
 
 def _dump_inline_table(section):
     """Preserve inline table in its compact syntax instead of expanding
@@ -798,6 +825,7 @@ def _dump_inline_table(section):
     else:
         return str(_dump_value(section))
 
+
 def _dump_value(v):
     dump_funcs = {
         str: lambda: _dump_str(v),
@@ -805,12 +833,13 @@ def _dump_value(v):
         list: lambda: _dump_list(v),
         bool: lambda: str(v).lower(),
         float: lambda: _dump_float(v),
-        datetime.datetime: lambda: v.isoformat()[:19]+'Z',
+        datetime.datetime: lambda: v.isoformat()[:19] + 'Z',
     }
     # Lookup function corresponding to v's type
     dump_fn = dump_funcs.get(type(v))
     # Evaluate function (if it exists) else return v
     return dump_fn() if dump_fn is not None else v
+
 
 def _dump_str(v):
     v = "%r" % v
@@ -822,7 +851,8 @@ def _dump_str(v):
         v = v.replace("\\'", "'")
         v = v.replace('"', '\\"')
     v = v.replace("\\x", "\\u00")
-    return str('"'+v+'"')
+    return str('"' + v + '"')
+
 
 def _dump_list(v):
     t = []
@@ -840,6 +870,7 @@ def _dump_list(v):
         t = s
     retval += "]"
     return retval
+
 
 def _dump_float(v):
     return "{0:.16g}".format(v).replace("e+0", "e+").replace("e-0", "e-")


### PR DESCRIPTION
Hi! 

In PR #99, there was some discussing regarding the use of `os.linesep` instead of manually looking for/replacing `\r\n` or `\n`.

As such, I'd like to PEP8ify the code base in [toml.py](https://github.com/uiri/toml/blob/master/toml.py) before I come with such a PR.
(It would make it easier to conform to a standard of code quality, plus help the refactoring quite a bit in my experience).

This PR thus contains:

- A [.flake8](https://github.com/x10an14/toml/blob/cc6a2dc8d8558c7d2c75c00b7b1eb894b9d1efae/.flake8) config file specifying the PEP8 rules I'd suggest this project use (which is absolutely open for debate!).
- A `toml.py` file edited to live up to the rules specified in `.flake8`, with one exception, as stated in this [commit](https://github.com/x10an14/toml/commit/cc6a2dc8d8558c7d2c75c00b7b1eb894b9d1efae#diff-540ed609f086a01ee6f84e1a7bba5f6e).

This PR is also based off on PR #99, and I'll rebase this on top of that one as required if there's anything more to be done in #99. =)