### PR TITLE
floats like 10.0 should remain floats when dumped

### DIFF
--- a/toml.py
+++ b/toml.py
@@ -920,4 +920,4 @@ def _dump_list(v):
 
 
 def _dump_float(v):
-    return "{0:.16g}".format(v).replace("e+0", "e+").replace("e-0", "e-")
+    return "{0:.16}".format(v).replace("e+0", "e+").replace("e-0", "e-")


### PR DESCRIPTION
Currently, a value like `10.0` will be dumped out as `10`, whereas it should be dumped out as `10.0`.

From the [python docs](https://docs.python.org/3.4/library/string.html#format-specification-mini-language), dropping the `g` in the format string yields the following behaviour:
```
Similar to 'g', except that fixed-point notation, when used, has at least one digit past the decimal point. The default precision is as high as needed to represent the particular value. The overall effect is to match the output of str() as altered by the other format modifiers.
```