### PR TITLE
New API: Encoder / Decoder model

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -26,6 +26,14 @@ def test_valid_tests():
         toml.dumps(toml.load(open(os.path.join(valid_dir, f))))
 
 
+def test__dict():
+    class TestDict(dict):
+        pass
+
+    assert isinstance(toml.loads(
+        TEST_STR, _dict=TestDict), TestDict)
+
+
 def test_dict_decoder():
     class TestDict(dict):
         pass

--- a/toml/__init__.py
+++ b/toml/__init__.py
@@ -12,8 +12,9 @@ __spec__ = "0.4.0"
 load = decoder.load
 loads = decoder.loads
 TomlDecoder = decoder.TomlDecoder
+TomlDecodeError = decoder.TomlDecodeError
 
 dump = encoder.dump
 dumps = encoder.dumps
-
-TomlDecodeError = decoder.TomlDecodeError
+TomlEncoder = encoder.TomlEncoder
+TomlArraySeparatorEncoder = encoder.TomlArraySeparatorEncoder

--- a/toml/__init__.py
+++ b/toml/__init__.py
@@ -6,7 +6,7 @@ Released under the MIT license.
 from toml import encoder
 from toml import decoder
 
-__version__ = "0.9.3"
+__version__ = "0.10.0"
 __spec__ = "0.4.0"
 
 load = decoder.load

--- a/toml/decoder.py
+++ b/toml/decoder.py
@@ -62,7 +62,7 @@ def _strictly_valid_num(n):
     return True
 
 
-def load(f, decoder=None):
+def load(f, _dict=dict, decoder=None):
     """Parses named file or files as toml and returns a dictionary
 
     Args:
@@ -82,7 +82,7 @@ def load(f, decoder=None):
 
     if isinstance(f, basestring):
         with io.open(f, encoding='utf-8') as ffile:
-            return loads(ffile.read(), decoder)
+            return loads(ffile.read(), _dict, decoder)
     elif isinstance(f, list):
         from os import path as op
         from warnings import warn
@@ -97,14 +97,14 @@ def load(f, decoder=None):
         d = decoder.get_empty_table()
         for l in f:
             if op.exists(l):
-                d.update(load(l, decoder))
+                d.update(load(l, _dict, decoder))
             else:
                 warn("Non-existent filename in list with at least one valid "
                      "filename")
         return d
     else:
         try:
-            return loads(f.read(), decoder)
+            return loads(f.read(), _dict, decoder)
         except AttributeError:
             raise TypeError("You can only load a file descriptor, filename or "
                             "list")
@@ -113,7 +113,7 @@ def load(f, decoder=None):
 _groupname_re = re.compile(r'^[A-Za-z0-9_-]+$')
 
 
-def loads(s, decoder=None):
+def loads(s, _dict=dict, decoder=None):
     """Parses string as toml
 
     Args:
@@ -130,7 +130,7 @@ def loads(s, decoder=None):
 
     implicitgroups = []
     if decoder is None:
-        decoder = TomlDecoder()
+        decoder = TomlDecoder(_dict)
     retval = decoder.get_empty_table()
     currentlevel = retval
     if not isinstance(s, basestring):

--- a/toml/decoder.py
+++ b/toml/decoder.py
@@ -97,7 +97,7 @@ def load(f, decoder=None):
         d = decoder.get_empty_table()
         for l in f:
             if op.exists(l):
-                d.update(load(l))
+                d.update(load(l, decoder))
             else:
                 warn("Non-existent filename in list with at least one valid "
                      "filename")

--- a/toml/encoder.py
+++ b/toml/encoder.py
@@ -43,11 +43,11 @@ def dumps(o, encoder=None):
 
     retval = ""
     if encoder is None:
-        encoder = TomlEncoder()
+        encoder = TomlEncoder(o.__class__)
     addtoretval, sections = encoder._dump_sections(o, "")
     retval += addtoretval
-    while sections != {}:
-        newsections = {}
+    while sections:
+        newsections = encoder.get_empty_table()
         for section in sections:
             addtoretval, addtosections = encoder._dump_sections(
                 sections[section], section)
@@ -66,14 +66,18 @@ def dumps(o, encoder=None):
 
 class TomlEncoder(object):
 
-    def __init__(self, preserve=False):
+    def __init__(self, _dict=dict, preserve=False):
+        self._dict = _dict
         self.preserve = preserve
+
+    def get_empty_table(self):
+        return self._dict()
 
     def _dump_sections(self, o, sup):
         retstr = ""
         if sup != "" and sup[-1] != ".":
             sup += '.'
-        retdict = o.__class__()
+        retdict = self._dict()
         arraystr = ""
         for section in o:
             section = unicode(section)
@@ -99,8 +103,8 @@ class TomlEncoder(object):
                                 arraytabstr += s
                             else:
                                 arraystr += s
-                        while d != {}:
-                            newd = {}
+                        while d:
+                            newd = self._dict()
                             for dsec in d:
                                 s1, d1 = self._dump_sections(d[dsec], sup +
                                                              qsection + "." +

--- a/toml/encoder.py
+++ b/toml/encoder.py
@@ -200,6 +200,12 @@ class TomlEncoder(object):
         return (retstr, retdict)
 
 
+class TomlPreserveInlineDictEncoder(TomlEncoder):
+
+    def __init__(self, _dict=dict):
+        super(self.__class__, self).__init__(_dict, True)
+
+
 class TomlArraySeparatorEncoder(TomlEncoder):
 
     def __init__(self, _dict=dict, preserve=False, separator=","):

--- a/toml/encoder.py
+++ b/toml/encoder.py
@@ -198,3 +198,31 @@ class TomlEncoder(object):
                 retdict[qsection] = o[section]
         retstr += arraystr
         return (retstr, retdict)
+
+
+class TomlArraySeparatorEncoder(TomlEncoder):
+
+    def __init__(self, _dict=dict, preserve=False, separator=","):
+        super(self.__class__, self).__init__(_dict, preserve)
+        if separator.strip() == "":
+            separator = "," + separator
+        elif separator.strip(' \t\n\r,'):
+            raise ValueError("Invalid separator for arrays")
+        self.separator = separator
+
+    def dump_list(self, v):
+        t = []
+        retval = "["
+        for u in v:
+            t.append(self.dump_value(u))
+        while t != []:
+            s = []
+            for u in t:
+                if isinstance(u, list):
+                    for r in u:
+                        s.append(r)
+                else:
+                    retval += " " + unicode(u) + self.separator
+            t = s
+        retval += "]"
+        return retval

--- a/toml/encoder.py
+++ b/toml/encoder.py
@@ -44,12 +44,12 @@ def dumps(o, encoder=None):
     retval = ""
     if encoder is None:
         encoder = TomlEncoder(o.__class__)
-    addtoretval, sections = encoder._dump_sections(o, "")
+    addtoretval, sections = encoder.dump_sections(o, "")
     retval += addtoretval
     while sections:
         newsections = encoder.get_empty_table()
         for section in sections:
-            addtoretval, addtosections = encoder._dump_sections(
+            addtoretval, addtosections = encoder.dump_sections(
                 sections[section], section)
 
             if addtoretval or (not addtoretval and not addtosections):
@@ -62,104 +62,6 @@ def dumps(o, encoder=None):
                 newsections[section + "." + s] = addtosections[s]
         sections = newsections
     return retval
-
-
-class TomlEncoder(object):
-
-    def __init__(self, _dict=dict, preserve=False):
-        self._dict = _dict
-        self.preserve = preserve
-
-    def get_empty_table(self):
-        return self._dict()
-
-    def _dump_sections(self, o, sup):
-        retstr = ""
-        if sup != "" and sup[-1] != ".":
-            sup += '.'
-        retdict = self._dict()
-        arraystr = ""
-        for section in o:
-            section = unicode(section)
-            qsection = section
-            if not re.match(r'^[A-Za-z0-9_-]+$', section):
-                if '"' in section:
-                    qsection = "'" + section + "'"
-                else:
-                    qsection = '"' + section + '"'
-            if not isinstance(o[section], dict):
-                arrayoftables = False
-                if isinstance(o[section], list):
-                    for a in o[section]:
-                        if isinstance(a, dict):
-                            arrayoftables = True
-                if arrayoftables:
-                    for a in o[section]:
-                        arraytabstr = "\n"
-                        arraystr += "[[" + sup + qsection + "]]\n"
-                        s, d = self._dump_sections(a, sup + qsection)
-                        if s:
-                            if s[0] == "[":
-                                arraytabstr += s
-                            else:
-                                arraystr += s
-                        while d:
-                            newd = self._dict()
-                            for dsec in d:
-                                s1, d1 = self._dump_sections(d[dsec], sup +
-                                                             qsection + "." +
-                                                             dsec)
-                                if s1:
-                                    arraytabstr += ("[" + sup + qsection +
-                                                    "." + dsec + "]\n")
-                                    arraytabstr += s1
-                                for s1 in d1:
-                                    newd[dsec + "." + s1] = d1[s1]
-                            d = newd
-                        arraystr += arraytabstr
-                else:
-                    if o[section] is not None:
-                        retstr += (qsection + " = " +
-                                   unicode(_dump_value(o[section])) + '\n')
-            elif self.preserve and isinstance(o[section], InlineTableDict):
-                retstr += (qsection + " = " + _dump_inline_table(o[section]))
-            else:
-                retdict[qsection] = o[section]
-        retstr += arraystr
-        return (retstr, retdict)
-
-
-def _dump_inline_table(section):
-    """Preserve inline table in its compact syntax instead of expanding
-    into subsection.
-
-    https://github.com/toml-lang/toml#user-content-inline-table
-    """
-    retval = ""
-    if isinstance(section, dict):
-        val_list = []
-        for k, v in section.items():
-            val = _dump_inline_table(v)
-            val_list.append(k + " = " + val)
-        retval += "{ " + ", ".join(val_list) + " }\n"
-        return retval
-    else:
-        return unicode(_dump_value(section))
-
-
-def _dump_value(v):
-    dump_funcs = {
-        str: lambda: _dump_str(v),
-        unicode: lambda: _dump_str(v),
-        list: lambda: _dump_list(v),
-        bool: lambda: unicode(v).lower(),
-        float: lambda: _dump_float(v),
-        datetime.datetime: lambda: v.isoformat().replace('+00:00', 'Z'),
-    }
-    # Lookup function corresponding to v's type
-    dump_fn = dump_funcs.get(type(v))
-    # Evaluate function (if it exists) else return v
-    return dump_fn() if dump_fn is not None else v
 
 
 def _dump_str(v):
@@ -190,13 +92,109 @@ def _dump_str(v):
     return unicode('"' + v[0] + '"')
 
 
-def _dump_list(v):
-    retval = "["
-    for u in v:
-        retval += " " + unicode(_dump_value(u)) + ","
-    retval += "]"
-    return retval
-
-
 def _dump_float(v):
     return "{0:.16}".format(v).replace("e+0", "e+").replace("e-0", "e-")
+
+
+class TomlEncoder(object):
+
+    def __init__(self, _dict=dict, preserve=False):
+        self._dict = _dict
+        self.preserve = preserve
+        self.dump_funcs = {
+            str: _dump_str,
+            unicode: _dump_str,
+            list: self.dump_list,
+            bool: lambda v: unicode(v).lower(),
+            float: _dump_float,
+            datetime.datetime: lambda v: v.isoformat().replace('+00:00', 'Z'),
+        }
+
+    def get_empty_table(self):
+        return self._dict()
+
+    def dump_list(self, v):
+        retval = "["
+        for u in v:
+            retval += " " + unicode(self.dump_value(u)) + ","
+        retval += "]"
+        return retval
+
+    def dump_inline_table(self, section):
+        """Preserve inline table in its compact syntax instead of expanding
+        into subsection.
+
+        https://github.com/toml-lang/toml#user-content-inline-table
+        """
+        retval = ""
+        if isinstance(section, dict):
+            val_list = []
+            for k, v in section.items():
+                val = self.dump_inline_table(v)
+                val_list.append(k + " = " + val)
+            retval += "{ " + ", ".join(val_list) + " }\n"
+            return retval
+        else:
+            return unicode(self.dump_value(section))
+
+    def dump_value(self, v):
+        # Lookup function corresponding to v's type
+        dump_fn = self.dump_funcs.get(type(v))
+        # Evaluate function (if it exists) else return v
+        return dump_fn(v) if dump_fn is not None else v
+
+    def dump_sections(self, o, sup):
+        retstr = ""
+        if sup != "" and sup[-1] != ".":
+            sup += '.'
+        retdict = self._dict()
+        arraystr = ""
+        for section in o:
+            section = unicode(section)
+            qsection = section
+            if not re.match(r'^[A-Za-z0-9_-]+$', section):
+                if '"' in section:
+                    qsection = "'" + section + "'"
+                else:
+                    qsection = '"' + section + '"'
+            if not isinstance(o[section], dict):
+                arrayoftables = False
+                if isinstance(o[section], list):
+                    for a in o[section]:
+                        if isinstance(a, dict):
+                            arrayoftables = True
+                if arrayoftables:
+                    for a in o[section]:
+                        arraytabstr = "\n"
+                        arraystr += "[[" + sup + qsection + "]]\n"
+                        s, d = self.dump_sections(a, sup + qsection)
+                        if s:
+                            if s[0] == "[":
+                                arraytabstr += s
+                            else:
+                                arraystr += s
+                        while d:
+                            newd = self._dict()
+                            for dsec in d:
+                                s1, d1 = self.dump_sections(d[dsec], sup +
+                                                            qsection + "." +
+                                                            dsec)
+                                if s1:
+                                    arraytabstr += ("[" + sup + qsection +
+                                                    "." + dsec + "]\n")
+                                    arraytabstr += s1
+                                for s1 in d1:
+                                    newd[dsec + "." + s1] = d1[s1]
+                            d = newd
+                        arraystr += arraytabstr
+                else:
+                    if o[section] is not None:
+                        retstr += (qsection + " = " +
+                                   unicode(self.dump_value(o[section])) + '\n')
+            elif self.preserve and isinstance(o[section], InlineTableDict):
+                retstr += (qsection + " = " +
+                           self.dump_inline_table(o[section]))
+            else:
+                retdict[qsection] = o[section]
+        retstr += arraystr
+        return (retstr, retdict)

--- a/toml/ordered.py
+++ b/toml/ordered.py
@@ -1,0 +1,15 @@
+from collections import OrderedDict
+from toml import TomlEncoder
+from toml import TomlDecoder
+
+
+class TomlOrderedDecoder(TomlDecoder):
+
+    def __init__(self):
+        super(self.__class__, self).__init__(_dict=OrderedDict)
+
+
+class TomlOrderedEncoder(TomlEncoder):
+
+    def __init__(self):
+        super(self.__class__, self).__init__(_dict=OrderedDict)


### PR DESCRIPTION
Firstly, I am sorry that git's diff algorithm can't understand the changes in this PR for the life of it. Even in split mode, it looks far messier than it actually is. See #135 for context around splitting up the module into a package of modules (i.e. what the hell happened in the base that this PR is `diff`'d against).

So the 0.9.X Toml API is something like:

`dumps(o, preserve=False)`
`loads(s, _dict=dict)`

The new Toml API I'm proposing is something like:

`dumps(o, decoder=None)`
`loads(s, encoder=None)`

Given a `None` encoder or decoder, the method creates one from the default `TomlEncoder` or `TomlDecoder` class. Examples of custom Encoders are: `TomlArraySeparatorEncoder`, `TomlPreserveInlineDictEncoder`, and the `TomlOrderedEncoder`. An example of a custom Decoder is `TomlOrderedDecoder`.

The `TomlArraySeparatorEncoder` seems kind of clumsy but I am not sure which facility is general purpose enough to expose while also accomplishing the desired goal of custom newlines/spacing around encoded array elements.

So, I want to minimize breaking downstream users of the library. This model has an inherent flexibility which avoids future breakage by containing it within the Decoder/Encoder class. Of course, the APIs presented by those classes could change. One strategy to avoid future breakages caused by *those* changes is to include a set of custom Encoders/Decoders with the `toml` library.

To that end, I am soliciting feedback on these changes and the overall new API design.