### PR TITLE
Added support for Local Dates

### DIFF
--- a/examples/example-v0.4.0.toml
+++ b/examples/example-v0.4.0.toml
@@ -166,13 +166,16 @@ False = false
 ################################################################################
 ## Datetime
 
-# Datetimes are RFC 3339 dates.
+# Datetimes are RFC 3339 dates.If you include only the date portion of an 
+# RFC 3339 formatted date-time, it will represent that entire day without 
+# any relation to an offset or timezone.
 
 [datetime]
 
 key1 = 1979-05-27T07:32:00Z
 key2 = 1979-05-27T00:32:00-07:00
 key3 = 1979-05-27T00:32:00.999999-07:00
+key4 = 1979-05-27
 
 
 ################################################################################

--- a/toml/decoder.py
+++ b/toml/decoder.py
@@ -382,10 +382,15 @@ def _load_date(val):
     except ValueError:
         tz = None
     try:
-        d = datetime.datetime(
-            int(val[:4]), int(val[5:7]),
-            int(val[8:10]), int(val[11:13]),
-            int(val[14:16]), int(val[17:19]), microsecond, tz)
+        if len(val) == 10:
+            d = datetime.date(
+                int(val[:4]), int(val[5:7]),
+                int(val[8:10]))
+        else:
+            d = datetime.datetime(
+                int(val[:4]), int(val[5:7]),
+                int(val[8:10]), int(val[11:13]),
+                int(val[14:16]), int(val[17:19]), microsecond, tz)
     except ValueError:
         return None
     return d


### PR DESCRIPTION
Adds support for Local Dates, which are in the spec on `toml-lang/toml/master` but not in the official 4.0 spec release. 

```toml
ldt1 = 1979-05-27T07:32:00
ldt2 = 1979-05-27T00:32:00.999999
ldt3 = 1979-05-27
```
Becomes
```python
In [3]: toml.load(f)
Out[3]:
{'ldt1': datetime.datetime(1979, 5, 27, 7, 32),
 'ldt2': datetime.datetime(1979, 5, 27, 0, 32, 0, 999999),
 'ldt3': datetime.date(1979, 5, 27)}
```