### PR TITLE
Produce a universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = True


### PR DESCRIPTION
Hi there!

Since this package is a pure Python package, I believe the wheels it produces should be compatible with both Python 2 and Python 3.

By marking it as producing universal wheels, it will produce one wheel instead of two. This makes it a tiny bit easier for people to upload wheels to their internal PyPI registries, plus improves cache performance in pip if you're using `toml` from both Python 2 and Python 3.

More details about universal wheels: https://wheel.readthedocs.io/en/stable/#defining-the-python-version

### Before

```bash
$ python setup.py bdist_wheel
$ ls dist
toml-0.10.0-py2-none-any.whl
```

### After

```bash
$ python setup.py bdist_wheel
$ ls dist
toml-0.10.0-py2.py3-none-any.whl
```