### PR TITLE
Add support for hexadecimal, octal and binary numbers

### DIFF
--- a/toml/decoder.py
+++ b/toml/decoder.py
@@ -703,7 +703,7 @@ class TomlDecoder(object):
             elif v[0] == '+':
                 v = v[1:]
             v = v.replace('_', '')
-            if v[1] not in ['x', 'o', 'b']:
+            if 'x' not in v:
                 if '.' in v or 'e' in v or 'E' in v:
                     if '.' in v and v.split('.', 1)[1] == '':
                         raise ValueError("This float is missing digits after "
@@ -713,7 +713,7 @@ class TomlDecoder(object):
                                          "digit")
                     v = float(v)
                     itype = "float"
-            else:
+            if itype == "int":
                 v = int(v, 0)
             if neg:
                 return (0 - v, itype)

--- a/toml/decoder.py
+++ b/toml/decoder.py
@@ -75,8 +75,12 @@ def _strictly_valid_num(n):
         return False
     if len(n) == 1:
         return True
-    if n[0] == '0' and n[1] != '.':
-        return False
+    if n[0] == '0':
+        if n[1] in ['o','b','x']:
+            n = int(n, 0)
+            return True
+        if n[1] != '.':
+            return False
     if n[0] == '+' or n[0] == '-':
         n = n[1:]
         if n[0] == '0' and n[1] != '.':
@@ -712,7 +716,7 @@ class TomlDecoder(object):
                 v = float(v)
                 itype = "float"
             else:
-                v = int(v)
+                v = int(v, 0)
             if neg:
                 return (0 - v, itype)
             return (v, itype)

--- a/toml/decoder.py
+++ b/toml/decoder.py
@@ -76,10 +76,7 @@ def _strictly_valid_num(n):
     if len(n) == 1:
         return True
     if n[0] == '0':
-        if n[1] in ['o','b','x']:
-            n = int(n, 0)
-            return True
-        if n[1] != '.':
+        if n[1] not in ['.', 'o', 'b', 'x']:
             return False
     if n[0] == '+' or n[0] == '-':
         n = n[1:]
@@ -706,15 +703,16 @@ class TomlDecoder(object):
             elif v[0] == '+':
                 v = v[1:]
             v = v.replace('_', '')
-            if '.' in v or 'e' in v or 'E' in v:
-                if '.' in v and v.split('.', 1)[1] == '':
-                    raise ValueError("This float is missing digits after "
-                                     "the point")
-                if v[0] not in '0123456789':
-                    raise ValueError("This float doesn't have a leading "
-                                     "digit")
-                v = float(v)
-                itype = "float"
+            if v[1] not in ['x', 'o', 'b']:
+                if '.' in v or 'e' in v or 'E' in v:
+                    if '.' in v and v.split('.', 1)[1] == '':
+                        raise ValueError("This float is missing digits after "
+                                         "the point")
+                    if v[0] not in '0123456789':
+                        raise ValueError("This float doesn't have a leading "
+                                         "digit")
+                    v = float(v)
+                    itype = "float"
             else:
                 v = int(v, 0)
             if neg:


### PR DESCRIPTION
Now this works
```
> import toml
> a="var = 0x100"
> toml.loads(a)
{u'var': 256}
```
As well as this:
```
> import toml
> a = """
... hex = 0xAB03
... binary = 0b100101
... octal = 0o630
... """
> toml.loads(a)
{u'octal': 408, u'binary': 37, u'hex': 43779}
```
acording to [0.5.0 spec](https://github.com/toml-lang/toml/blob/master/versions/en/toml-v0.5.0.md#user-content-integer)

> Non-negative integer values may also be expressed in hexadecimal, octal, or binary.