### PR TITLE
Added support for encoding of tuples.

### DIFF
--- a/toml/encoder.py
+++ b/toml/encoder.py
@@ -116,6 +116,7 @@ class TomlEncoder(object):
             str: _dump_str,
             unicode: _dump_str,
             list: self.dump_list,
+            tuple: self.dump_list,
             bool: lambda v: unicode(v).lower(),
             int: lambda v: v,
             float: _dump_float,


### PR DESCRIPTION
Right now tuples will are encoded using a to string call (I think - that is the behavior I observed), this just makes tuples get encoded as lists, so they can be decoded.