### PR TITLE
Use isinstance, as object type may inherit from type

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -160,3 +160,11 @@ def test_warnings():
 def test_commutativity():
     o = toml.loads(toml.dumps(TEST_DICT))
     assert o == toml.loads(toml.dumps(o))
+
+
+def test_bug_190():
+    class String(str):
+        pass
+
+    o = toml.dumps({'test': String('test string')})
+    assert o == 'test = "test string"\n'

--- a/toml/encoder.py
+++ b/toml/encoder.py
@@ -153,7 +153,10 @@ class TomlEncoder(object):
 
     def dump_value(self, v):
         # Lookup function corresponding to v's type
-        dump_fn = self.dump_funcs.get(type(v))
+        dump_fn = None
+        for typ in self.dump_funcs:
+            if isinstance(v, typ):
+                dump_fn = self.dump_funcs.get(typ)
         if dump_fn is None and hasattr(v, '__iter__'):
             dump_fn = self.dump_funcs[list]
         # Evaluate function (if it exists) else return v


### PR DESCRIPTION
I am working on integrating this project with another. In this project, we have some types that inherit from base types.

Using `self.dump_funcs.get(type(v))` results in `None` because the type of the object is defined as:

```
class AnsibleUnicode(AnsibleBaseYAMLObject, text_type):
    ''' sub class for unicode objects '''
    pass
```

Using `isinstance` would allow for this to work.

Before this change:

```toml
[all.vars]
group_var1 = value2
```

After this change:

```toml
[all.vars]
group_var1 = "value2"
```