### PR TITLE
Add trove classifier for license

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,10 @@ setup(
     author_email="uiri@xqz.ca",
     url="https://github.com/uiri/toml",
     packages=['toml'],
-    license="License :: OSI Approved :: MIT License",
+    license="MIT",
     long_description=readme_string,
     classifiers=[
+        'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',


### PR DESCRIPTION
The trove classifiers are listed on PyPI to help users know -- at a
glance -- what license the project uses. Helps users decide if the
library is appropriate for integration. A full list of available trove
classifiers can be found at:

https://pypi.org/pypi?%3Aaction=list_classifiers

The setuptools "license" argument is not intended to use trove
classifier notation. Simplify it to "MIT". Details can be found:

https://docs.python.org/3/distutils/setupscript.html#additional-meta-data