### PR TITLE
Include tests in source distribution; clean up MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,5 @@
-include toml/__init__.py
-include toml/decoder.py
-include toml/encoder.py
-include toml/tz.py
-include setup.py
-include toml.pyi
-include README.rst
 include LICENSE
+include README.rst
+include toml.pyi
+include tox.ini
+recursive-include tests *.py *.sh


### PR DESCRIPTION
Don't need to specify `setup.py` as it is included automatically by `setuptools`.

Don't need to include package Python files (`toml/*`) as they're included automatically by `setuptools`.

Alphabetized list.

Fixes #192