### PR TITLE
Add support for decimal.Decimal encoding

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,6 +3,7 @@ import copy
 import pytest
 import os
 import sys
+from decimal import Decimal
 
 from toml.decoder import InlineTableDict
 
@@ -100,6 +101,15 @@ def test_tuple():
     d = {"a": (3, 4)}
     o = toml.loads(toml.dumps(d))
     assert o == toml.loads(toml.dumps(o))
+
+
+def test_decimal():
+    PLACES = Decimal(10) ** -4
+
+    d = {"a": Decimal("0.1")}
+    o = toml.loads(toml.dumps(d))
+    assert o == toml.loads(toml.dumps(o))
+    assert Decimal(o["a"]).quantize(PLACES) == d["a"].quantize(PLACES)
 
 
 def test_invalid_tests():

--- a/toml/encoder.py
+++ b/toml/encoder.py
@@ -1,6 +1,7 @@
 import datetime
 import re
 import sys
+from decimal import Decimal
 
 from toml.decoder import InlineTableDict
 
@@ -119,6 +120,7 @@ class TomlEncoder(object):
             bool: lambda v: unicode(v).lower(),
             int: lambda v: v,
             float: _dump_float,
+            Decimal: _dump_float,
             datetime.datetime: lambda v: v.isoformat().replace('+00:00', 'Z'),
             datetime.time: _dump_time,
             datetime.date: lambda v: v.isoformat()


### PR DESCRIPTION
In `toml 0.9.6`, `decimal.Decimal` values are converted into strings as follows:

```py
import toml
from decimal import Decimal

d = {"a": Decimal("0.1")}
print(toml.dumps(d))
```

```
a = "Decimal('0.1')"
```

It would be helpful if `toml.dumps` method output `float` values when input value types are `decimal.Decimal`:

```
a = 0.1
```
