### PR TITLE
Call to super should use explicit class

### DIFF
--- a/toml/encoder.py
+++ b/toml/encoder.py
@@ -219,13 +219,13 @@ class TomlEncoder(object):
 class TomlPreserveInlineDictEncoder(TomlEncoder):
 
     def __init__(self, _dict=dict):
-        super(self.__class__, self).__init__(_dict, True)
+        super(TomlPreserveInlineDictEncoder, self).__init__(_dict, True)
 
 
 class TomlArraySeparatorEncoder(TomlEncoder):
 
     def __init__(self, _dict=dict, preserve=False, separator=","):
-        super(self.__class__, self).__init__(_dict, preserve)
+        super(TomlArraySeparatorEncoder, self).__init__(_dict, preserve)
         if separator.strip() == "":
             separator = "," + separator
         elif separator.strip(' \t\n\r,'):


### PR DESCRIPTION
Due to the fact that `TomlArraySeparatorEncoder` (and `TomlPreserveInlineDictEncoder`) call `super` using `self.__class__` if you inherit from one of those classes a recursion error is encountered.

```
Traceback (most recent call last):
  File "/Users/matt/projects/ansibledev/ansible/bin/ansible-inventory", line 118, in <module>
    exit_code = cli.run()
  File "/Users/matt/projects/ansibledev/ansible/lib/ansible/cli/inventory.py", line 185, in run
    results = self.dump(results)
  File "/Users/matt/projects/ansibledev/ansible/lib/ansible/cli/inventory.py", line 209, in dump
    results = toml.dumps(stuff, encoder=AnsibleTomlEncoder())
  File "/Users/matt/projects/ansibledev/ansible/lib/ansible/plugins/inventory/toml.py", line 110, in __init__
    super(AnsibleTomlEncoder, self).__init__(*args, **kwargs)
  File "/Users/matt/venvs/ansibledev/lib/python3.7/site-packages/toml/encoder.py", line 228, in __init__
    super(self.__class__, self).__init__(_dict, preserve)
  File "/Users/matt/venvs/ansibledev/lib/python3.7/site-packages/toml/encoder.py", line 228, in __init__
    super(self.__class__, self).__init__(_dict, preserve)
  File "/Users/matt/venvs/ansibledev/lib/python3.7/site-packages/toml/encoder.py", line 228, in __init__
    super(self.__class__, self).__init__(_dict, preserve)
  [Previous line repeated 990 more times]
RecursionError: maximum recursion depth exceeded while calling a Python object
```

This is due to the fact that `self.__class__` will be the class that inherits from `TomlArraySeparatorEncoder` rather than `TomlArraySeparatorEncoder` itself.

The value specified to `super` should be explicit.

It may be prudent to inherit from one of these classes, to avoid duplication of code, and additionally, modify something such as `dump_funcs`.