### PR TITLE
Prettify test suite and make it more robust

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/toml-test"]
+	path = tests/toml-test
+	url = https://github.com/BurntSushi/toml-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
  - "3.5"
  - "3.6"
  - "pypy"
+ - "pypy3.5"
 
 matrix:
   include:
@@ -15,19 +16,12 @@ matrix:
 
 notifications:
   email: false
-addons:
-  apt:
-    packages:
-    - git
-    - golang
 before_install:
  - export GOPATH=~/go
  - go get github.com/BurntSushi/toml-test
- - git clone https://github.com/BurntSushi/toml-test
 install:
  - pip install tox-travis
  - python setup.py install
- - chmod +x ./tests/*.sh
 script:
  - ~/go/bin/toml-test ./tests/decoding_test.sh
  - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
  - "3.5"
  - "3.6"
  - "pypy"
- - "pypy3.5"
+ - "pypy3"
 
 matrix:
   include:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(scope='session')
+def tests_dir():
+    return os.path.abspath(os.path.dirname(__file__))
+
+
+@pytest.fixture(scope='session')
+def toml_test_dir(tests_dir):
+    return os.path.join(tests_dir, 'toml-test', 'tests')
+
+
+@pytest.fixture(scope='session')
+def valid_dir(toml_test_dir):
+    return os.path.join(toml_test_dir, 'valid')
+
+
+@pytest.fixture(scope='session')
+def invalid_dir(toml_test_dir):
+    return os.path.join(toml_test_dir, 'invalid')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, py36, pypy
+envlist = py27, py33, py34, py35, py36, py37, pypy27, pypy35
 
 [testenv]
 deps =


### PR DESCRIPTION
* Added pytest fixtures for inline test data and test samples from
`toml-test` repo.
* Added `https://github.com/BurntSushi/toml-test` as a git submodule under
`tests/` dir.
* Added `py37` to `tox.ini`.
* Changed `pypy` to `pypy27, pypy35` in `tox.ini`.
* Simplified Travis config.