### PR TITLE
Fix a deprecation warning

### DIFF
--- a/toml/decoder.py
+++ b/toml/decoder.py
@@ -44,7 +44,7 @@ except NameError:
     FNFError = IOError
 
 
-TIME_RE = re.compile("([0-9]{2}):([0-9]{2}):([0-9]{2})(\.([0-9]{3,6}))?")
+TIME_RE = re.compile(r"([0-9]{2}):([0-9]{2}):([0-9]{2})(\.([0-9]{3,6}))?")
 
 
 class TomlDecodeError(ValueError):


### PR DESCRIPTION
I got the following warning with `Python 3.7` + `toml 0.10.0`

    toml/decoder.py:47: DeprecationWarning: invalid escape sequence \.
      TIME_RE = re.compile("([0-9]{2}):([0-9]{2}):([0-9]{2})(\.([0-9]{3,6}))?")

This warning could be avoidable by using raw string.
