### PR TITLE
Fix #217: dumps unable to detect circular refs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -12,7 +12,7 @@ exclude =
     .tox,
 
 max-line-length = 80
-ignore =
+ignore = W504
 
 # Output config:
 show-source = True

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -51,6 +51,19 @@ def test_valid_tests():
         toml.dumps(toml.load(open(os.path.join(valid_dir, f))))
 
 
+def test_circular_ref():
+    a = {}
+    b = {}
+    b['c'] = 4
+    b['self'] = b
+    a['b'] = b
+    with pytest.raises(ValueError):
+        toml.dumps(a)
+
+    with pytest.raises(ValueError):
+        toml.dumps(b)
+
+
 def test__dict():
     class TestDict(dict):
         pass

--- a/toml/encoder.py
+++ b/toml/encoder.py
@@ -46,7 +46,13 @@ def dumps(o, encoder=None):
         encoder = TomlEncoder(o.__class__)
     addtoretval, sections = encoder.dump_sections(o, "")
     retval += addtoretval
+    outer_objs = [id(o)]
     while sections:
+        section_ids = [id(section) for section in sections]
+        for outer_obj in outer_objs:
+            if outer_obj in section_ids:
+                raise ValueError("Circular reference detected")
+        outer_objs += section_ids
         newsections = encoder.get_empty_table()
         for section in sections:
             addtoretval, addtosections = encoder.dump_sections(


### PR DESCRIPTION
If an object is passed to dumps, and that object has a circular
reference, then dumps will raise a ValueError because an object with
circular references cannot be encoded as valid TOML.