### PR TITLE
Fix loading values when a line has " }" after a boolean

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -43,17 +43,6 @@ def test_bug_196():
     assert round_trip_bug_dict['x'] == bug_dict['x']
 
 
-def test_bug_black637():
-    expected = {'black': {'637': {'black': {
-        'allow_prereleases': True, 'python': '>3.6', 'version': '>=18.9b0'
-    }}}}
-
-    assert expected == toml.loads(r"""
-[black.637]
-black = { python=">3.6", version=">=18.9b0", allow_prereleases=true }
-""")
-
-
 def test_valid_tests():
     valid_dir = "toml-test/tests/valid/"
     for f in os.listdir(valid_dir):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -43,6 +43,17 @@ def test_bug_196():
     assert round_trip_bug_dict['x'] == bug_dict['x']
 
 
+def test_bug_black637():
+    expected = {'black': {'637': {'black': {
+        'allow_prereleases': True, 'python': '>3.6', 'version': '>=18.9b0'
+    }}}}
+
+    assert expected == toml.loads(r"""
+[black.637]
+black = { python=">3.6", version=">=18.9b0", allow_prereleases=true }
+""")
+
+
 def test_valid_tests():
     valid_dir = "toml-test/tests/valid/"
     for f in os.listdir(valid_dir):

--- a/toml/decoder.py
+++ b/toml/decoder.py
@@ -669,7 +669,8 @@ class TomlDecoder(object):
         while len(pair[-1]) and (pair[-1][0] != ' ' and pair[-1][0] != '\t' and
                                  pair[-1][0] != "'" and pair[-1][0] != '"' and
                                  pair[-1][0] != '[' and pair[-1][0] != '{' and
-                                 pair[-1] != 'true' and pair[-1] != 'false'):
+                                 pair[-1].strip() != 'true' and
+                                 pair[-1].strip() != 'false'):
             try:
                 float(pair[-1])
                 break


### PR DESCRIPTION
This PR aims to fix ambv/black#637

The issue can be reproduce as follows (`Python 3.7` with `toml 0.10.0`):

```pycon
>>> import toml
>>> toml.loads(r"""
... [tool.poetry.dev-dependencies]
... black = { python=">3.6", version=">=18.9b0", allow_prereleases=true }
... """)
Traceback (most recent call last):
  File "/home/.../site-packages/toml/decoder.py", line 456, in loads
    multibackslash)
  File "/home/.../site-packages/toml/decoder.py", line 725, in load_line
    value, vtype = self.load_value(pair[1], strictly_valid)
  File "/home/.../site-packages/toml/decoder.py", line 805, in load_value
    self.load_inline_object(v, inline_object)
  File "/home/.../site-packages/toml/decoder.py", line 624, in load_inline_object
    multibackslash)
  File "/home/.../site-packages/toml/decoder.py", line 678, in load_line
    raise ValueError("Invalid date or number")
ValueError: Invalid date or number

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 4, in <module>
  File "/home/.../site-packages/toml/decoder.py", line 458, in loads
    raise TomlDecodeError(str(err), original, pos)
toml.decoder.TomlDecodeError: Invalid date or number (line 3 column 1 char 32)
```