### PR TITLE
Add support for output to a file to toml.dump function: #223

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -183,7 +183,7 @@ class FakeFile(object):
         return self.written
 
 
-def test_dump():
+def test_dump(tmpdir):
     f = FakeFile()
     g = FakeFile()
     h = FakeFile()
@@ -191,6 +191,14 @@ def test_dump():
     toml.dump(toml.load(f), g)
     toml.dump(toml.load(g), h)
     assert g.written == h.written
+
+    a = str(tmpdir.join("a"))
+    b = str(tmpdir.join("b"))
+    c = str(tmpdir.join("c"))
+    toml.dump(TEST_DICT, a)
+    toml.dump(toml.load(a), b)
+    toml.dump(toml.load(b), c)
+    assert toml.load(a) == toml.load(b)
 
 
 def test_paths():

--- a/toml/encoder.py
+++ b/toml/encoder.py
@@ -1,4 +1,5 @@
 import datetime
+import io
 import re
 import sys
 from decimal import Decimal
@@ -7,6 +8,9 @@ from toml.decoder import InlineTableDict
 
 if sys.version_info >= (3,):
     unicode = str
+    binary_type = bytes
+else:
+    binary_type = str
 
 
 def dump(o, f):
@@ -14,7 +18,7 @@ def dump(o, f):
 
     Args:
         o: Object to dump into toml
-        f: File descriptor where the toml should be stored
+        f: File descriptor or file path where the toml should be stored
 
     Returns:
         String containing the toml corresponding to dictionary
@@ -23,9 +27,15 @@ def dump(o, f):
         TypeError: When anything other than file descriptor is passed
     """
 
-    if not f.write:
-        raise TypeError("You can only dump an object to a file descriptor")
     d = dumps(o)
+    try:
+        if not f.write:
+            raise TypeError("You can only dump an object to a file descriptor")
+    except AttributeError:
+        if isinstance(f, (unicode, binary_type)):
+            with io.open(f, "w", encoding="utf-8") as fd:
+                fd.write(d)
+            return d
     f.write(d)
     return d
 


### PR DESCRIPTION
This PR is to enhance `toml.dump` that output `toml` to a file. And still, keep the backward compatibility (Issue #223).

If passing a string to `toml.dump` function, open it as a file path and write `toml` content to the file.
And behave the same as before, if passing a file descriptor to `toml.dump` function.