### PR TITLE
String dump with correct escaping

### DIFF
--- a/toml/encoder.py
+++ b/toml/encoder.py
@@ -70,37 +70,37 @@ def dumps(o, encoder=None):
         sections = newsections
     return retval
 
-
-def _dump_str(v):
+def _dump_str(v, escape_unicode=True):
     if sys.version_info < (3,) and hasattr(v, 'decode') and isinstance(v, str):
         v = v.decode('utf-8')
-    v = "%r" % v
-    if v[0] == 'u':
-        v = v[1:]
-    singlequote = v.startswith("'")
-    if singlequote or v.startswith('"'):
-        v = v[1:-1]
-    if singlequote:
-        v = v.replace("\\'", "'")
-        v = v.replace('"', '\\"')
-    v = v.split("\\x")
-    while len(v) > 1:
-        i = -1
-        if not v[0]:
-            v = v[1:]
-        v[0] = v[0].replace("\\\\", "\\")
-        # No, I don't know why != works and == breaks
-        joinx = v[0][i] != "\\"
-        while v[0][:i] and v[0][i] == "\\":
-            joinx = not joinx
-            i -= 1
-        if joinx:
-            joiner = "x"
-        else:
-            joiner = "u00"
-        v = [v[0] + joiner + v[1]] + v[2:]
-    return unicode('"' + v[0] + '"')
-
+    else:
+        v = unicode(v)
+    out = ''
+    quote = '"""' if len(v.splitlines()) > 1 else '"'
+    for line in v.splitlines():
+        for char in line:
+            c = ord(char)
+            if (escape_unicode and c > 127) or c <= 0x1f or c == 0x7f:
+                h = hex(c)[2:]
+                if len(h) < 2:
+                    h = '0' + h
+                    out += '\\x'
+                if c > 255 and len(h) < 4:
+                    h = '0' * (4 - len(h)) + h
+                    out += '\\u'
+                if c > 65536 and len(h) < 8:
+                    h = '0' * (8 - len(h)) + h
+                    out += '\\U'
+                out += h
+            else:            
+                if char == '\\' or char == '"':
+                        out += '\\'
+                out += char
+        out += '\n'
+    out = out[:-1]
+    if quote == '"""':
+        out = '\n' + out
+    return unicode('%s%s%s' % (quote, out, quote))
 
 def _dump_float(v):
     return "{0:.16}".format(v).replace("e+0", "e+").replace("e-0", "e-")
@@ -116,7 +116,7 @@ def _dump_time(v):
 
 class TomlEncoder(object):
 
-    def __init__(self, _dict=dict, preserve=False):
+    def __init__(self, _dict=dict, preserve=False, escape_unicode=True):
         self._dict = _dict
         self.preserve = preserve
         self.dump_funcs = {


### PR DESCRIPTION
This pull request is not complete and there are things that require clarification:

- It passes tests except for test_bug_148 which I do not understand since it seems to test exactly opposite behavior to the one in the issue

- It may be easy to add an option to dump to multiline as well as escaping or not escaping all Unicode

When complete should fix #201 and indeed #148, related to #236 

Reference used: https://github.com/toml-lang/toml#user-content-string