### PR TITLE
Remove precision from dump float

### DIFF
--- a/toml/encoder.py
+++ b/toml/encoder.py
@@ -103,7 +103,7 @@ def _dump_str(v):
 
 
 def _dump_float(v):
-    return "{0:.16}".format(v).replace("e+0", "e+").replace("e-0", "e-")
+    return "{}".format(v).replace("e+0", "e+").replace("e-0", "e-")
 
 
 def _dump_time(v):


### PR DESCRIPTION
Precision in a python format string, without a type specifier, formats
the content as a _string_, where the precision indicates the maximum
field size. This results in numbers with a large integer part, but a
small decimal part, being truncated unnecessarily. eg.

    >>> '{0:.16}'.format(1555609276.1339364)
    '1555609276.133936'