### PR TITLE
Small documentation and argument update

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "restructuredtext.confPath": ""
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "restructuredtext.confPath": ""
-}

--- a/README.rst
+++ b/README.rst
@@ -114,6 +114,22 @@ corresponding TOML-formatted data.
 
 For more functions, view the API Reference below.
 
+Note
+----
+
+For Numpy users, by default the data types ``np.floatX`` will not be translated to floats by toml, but will instead be encoded as strings. To get around this, specify the ``TomlNumpyEncoder`` when saving your data.
+
+.. code:: pycon
+
+  >>> import toml
+  >>> import numpy as np
+  >>> a = np.arange(0, 10, dtype=np.double)
+  >>> output = {'a': a}
+  >>> toml.dumps(output)
+  'a = [ "0.0", "1.0", "2.0", "3.0", "4.0", "5.0", "6.0", "7.0", "8.0", "9.0",]\n'
+  >>> toml.dumps(output, encoder=toml.TomlNumpyEncoder())
+  'a = [ 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0,]\n'
+
 API Reference
 =============
 
@@ -148,12 +164,13 @@ API Reference
     * ``TomlDecodeError``: When an error occurs while decoding the
       TOML-formatted string
 
-``toml.dump(o, f)``
+``toml.dump(o, f, encoder=None)``
   Write a dictionary to a file containing TOML-formatted data
 
   :Args:
     * ``o``: An object to be converted into TOML
     * ``f``: A File descriptor where the TOML-formatted output should be stored
+    * ``encoder``: An instance of ``TomlEncoder`` (or subclass) for encoding the object. If ``None``, will default to ``TomlEncoder``
 
   :Returns:
     A string containing the TOML-formatted data corresponding to object ``o``
@@ -161,14 +178,17 @@ API Reference
   :Raises:
     * ``TypeError``: When anything other than file descriptor is passed
 
-``toml.dumps(o)``
+``toml.dumps(o, encoder=None)``
   Create a TOML-formatted string from an input object
 
   :Args:
     * ``o``: An object to be converted into TOML
+    * ``encoder``: An instance of ``TomlEncoder`` (or subclass) for encoding the object. If ``None``, will default to ``TomlEncoder``
 
   :Returns:
     A string containing the TOML-formatted data corresponding to object ``o``
+
+
 
 Licensing
 =========

--- a/toml/__init__.py
+++ b/toml/__init__.py
@@ -6,7 +6,7 @@ Released under the MIT license.
 from toml import encoder
 from toml import decoder
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"
 _spec_ = "0.5.0"
 
 load = decoder.load

--- a/toml/encoder.py
+++ b/toml/encoder.py
@@ -9,12 +9,13 @@ if sys.version_info >= (3,):
     unicode = str
 
 
-def dump(o, f):
+def dump(o, f, encoder=None):
     """Writes out dict as toml to a file
 
     Args:
         o: Object to dump into toml
         f: File descriptor where the toml should be stored
+        encoder: The ``TomlEncoder`` to use for constructing the output string
 
     Returns:
         String containing the toml corresponding to dictionary
@@ -25,7 +26,7 @@ def dump(o, f):
 
     if not f.write:
         raise TypeError("You can only dump an object to a file descriptor")
-    d = dumps(o)
+    d = dumps(o, encoder=encoder)
     f.write(d)
     return d
 
@@ -35,11 +36,22 @@ def dumps(o, encoder=None):
 
     Args:
         o: Object to dump into toml
-
-        preserve: Boolean parameter. If true, preserve inline tables.
+        encoder: The ``TomlEncoder`` to use for constructing the output string
 
     Returns:
         String containing the toml corresponding to dict
+
+    Examples:
+        ```python
+        >>> import toml
+        >>> output = {
+        ... 'a': "I'm a string",
+        ... 'b': ["I'm", "a", "list"],
+        ... 'c': 2400
+        ... }
+        >>> toml.dumps(output)
+        'a = "I\'m a string"\nb = [ "I\'m", "a", "list",]\nc = 2400\n'
+        ```
     """
 
     retval = ""


### PR DESCRIPTION
This pull request does two things:

1. In `toml.dump` allows passing an encoder argument. Currently, to use a non-standard encoder users are forced to use `toml.dumps` followed by file-writing themselves. `toml.dump` should include the encoder argument to avoid this.

2. Updated README documentation to show the new arguments and gives an example of using the `TomlNumpyEncoder`. I fell into quite the rut in my code because my numpy arrays were saving as strings. The only way I figured out how to solve it was finding an old closed issue and then trying to figure out the usage through reading the source code. Hopefully adding this documentation will help users moving forward.

I have also incremented to version to `0.10.1` in hopes that a release (or pre-release) will be made on PyPI so I can take the github dependency out of my setup.py :)