### PR TITLE
Extend TomlNumpyEncoder to numpy integer types.

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -119,6 +119,23 @@ def test_numpy_floats():
     assert o == toml.loads(toml.dumps(o, encoder=encoder))
 
 
+def test_numpy_ints():
+    import numpy as np
+
+    encoder = toml.TomlNumpyEncoder()
+    d = {'a': np.array([1, 3], dtype=np.int64)}
+    o = toml.loads(toml.dumps(d, encoder=encoder))
+    assert o == toml.loads(toml.dumps(o, encoder=encoder))
+
+    d = {'a': np.array([1, 3], dtype=np.int32)}
+    o = toml.loads(toml.dumps(d, encoder=encoder))
+    assert o == toml.loads(toml.dumps(o, encoder=encoder))
+
+    d = {'a': np.array([1, 3], dtype=np.int16)}
+    o = toml.loads(toml.dumps(d, encoder=encoder))
+    assert o == toml.loads(toml.dumps(o, encoder=encoder))
+
+
 def test_ordered():
     from toml import ordered as toml_ordered
     encoder = toml_ordered.TomlOrderedEncoder()

--- a/toml/encoder.py
+++ b/toml/encoder.py
@@ -118,10 +118,6 @@ def _dump_float(v):
     return "{}".format(v).replace("e+0", "e+").replace("e-0", "e-")
 
 
-def _dump_int(v):
-    return "{}".format(int(v))
-
-
 def _dump_time(v):
     utcoffset = v.utcoffset()
     if utcoffset is None:
@@ -140,7 +136,7 @@ class TomlEncoder(object):
             unicode: _dump_str,
             list: self.dump_list,
             bool: lambda v: unicode(v).lower(),
-            int: _dump_int,
+            int: lambda v: v,
             float: _dump_float,
             Decimal: _dump_float,
             datetime.datetime: lambda v: v.isoformat().replace('+00:00', 'Z'),
@@ -279,6 +275,9 @@ class TomlNumpyEncoder(TomlEncoder):
         self.dump_funcs[np.float16] = _dump_float
         self.dump_funcs[np.float32] = _dump_float
         self.dump_funcs[np.float64] = _dump_float
-        self.dump_funcs[np.int16] = _dump_int
-        self.dump_funcs[np.int32] = _dump_int
-        self.dump_funcs[np.int64] = _dump_int
+        self.dump_funcs[np.int16] = self._dump_int
+        self.dump_funcs[np.int32] = self._dump_int
+        self.dump_funcs[np.int64] = self._dump_int
+
+    def _dump_int(self, v):
+        return "{}".format(int(v))

--- a/toml/encoder.py
+++ b/toml/encoder.py
@@ -118,6 +118,10 @@ def _dump_float(v):
     return "{}".format(v).replace("e+0", "e+").replace("e-0", "e-")
 
 
+def _dump_int(v):
+    return "{}".format(int(v))
+
+
 def _dump_time(v):
     utcoffset = v.utcoffset()
     if utcoffset is None:
@@ -136,7 +140,7 @@ class TomlEncoder(object):
             unicode: _dump_str,
             list: self.dump_list,
             bool: lambda v: unicode(v).lower(),
-            int: lambda v: v,
+            int: _dump_int,
             float: _dump_float,
             Decimal: _dump_float,
             datetime.datetime: lambda v: v.isoformat().replace('+00:00', 'Z'),
@@ -275,3 +279,6 @@ class TomlNumpyEncoder(TomlEncoder):
         self.dump_funcs[np.float16] = _dump_float
         self.dump_funcs[np.float32] = _dump_float
         self.dump_funcs[np.float64] = _dump_float
+        self.dump_funcs[np.int16] = _dump_int
+        self.dump_funcs[np.int32] = _dump_int
+        self.dump_funcs[np.int64] = _dump_int


### PR DESCRIPTION
I have extend TomlNumpyEncoder to handle numpy integer types. I've also added the unit test for these cases.