### PR TITLE
Fix #258: Fix bad syntax handling

### DIFF
--- a/toml/decoder.py
+++ b/toml/decoder.py
@@ -355,6 +355,9 @@ def loads(s, _dict=dict, decoder=None):
                     raise TomlDecodeError("Found empty keyname. ", original, i)
                 keyname = 1
                 key += item
+    if keyname:
+        raise TomlDecodeError("Key name found without value."
+                              " Reached end of file.", original, len(s))
     s = ''.join(sl)
     s = s.split('\n')
     multikey = None


### PR DESCRIPTION
Fix a bug where a key without a value does not cause an error when it
is not followed by a newline at the end of a file.