### PR TITLE
Add support for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,9 @@ python:
  - "3.4"
  - "3.5"
  - "3.6"
+ - "3.7"
+ - "3.8"
  #- "pypy"
-
-matrix:
-  include:
-    - python: "3.7"
-      dist: xenial
-      sudo: true
 
 notifications:
   email: false

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, py36, py37, pypy
+envlist = py27, py33, py34, py35, py36, py37, py38, pypy
 
 [testenv]
 deps =


### PR DESCRIPTION
Also simplify `.travis.yml` a bit because [`sudo` no longer has any effect](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration) and because Xenial is now the default.
