### PR TITLE
dotted keys with multiline strings

### DIFF
--- a/toml/decoder.py
+++ b/toml/decoder.py
@@ -360,6 +360,7 @@ def loads(s, _dict=dict, decoder=None):
                               " Reached end of file.", original, len(s))
     s = ''.join(sl)
     s = s.split('\n')
+    multilevel = None
     multikey = None
     multilinestr = ""
     multibackslash = False
@@ -392,7 +393,8 @@ def loads(s, _dict=dict, decoder=None):
                     value, vtype = decoder.load_value(multilinestr)
                 except ValueError as err:
                     raise TomlDecodeError(str(err), original, pos)
-                currentlevel[multikey] = value
+                multilevel[multikey] = value
+                multilevel = None
                 multikey = None
                 multilinestr = ""
             else:
@@ -509,7 +511,7 @@ def loads(s, _dict=dict, decoder=None):
             except ValueError as err:
                 raise TomlDecodeError(str(err), original, pos)
             if ret is not None:
-                multikey, multilinestr, multibackslash = ret
+                multilevel, multikey, multilinestr, multibackslash = ret
     return retval
 
 
@@ -779,7 +781,7 @@ class TomlDecoder(object):
             raise ValueError("Duplicate keys!")
         except KeyError:
             if multikey:
-                return multikey, multilinestr, multibackslash
+                return currentlevel, multikey, multilinestr, multibackslash
             else:
                 currentlevel[pair[0]] = value
 


### PR DESCRIPTION
I've added a test for this: https://github.com/BurntSushi/toml-test/pull/57

fix #265

The problem is that when you call `currentlevel[pair[0]] = value` on line 786, you've re-assigned currentlevel thus isn't not the same as where you were calling `currentlevel[multikey] = value` on line 395, this get's around that problem by returning a new `multilevel` object.