### PR TITLE
relative imports

### DIFF
--- a/toml/__init__.py
+++ b/toml/__init__.py
@@ -3,8 +3,8 @@
 Released under the MIT license.
 """
 
-from toml import encoder
-from toml import decoder
+from . import encoder
+from . import decoder
 
 __version__ = "0.10.1"
 _spec_ = "0.5.0"

--- a/toml/decoder.py
+++ b/toml/decoder.py
@@ -4,7 +4,7 @@ from os import linesep
 import re
 import sys
 
-from toml.tz import TomlTz
+from .tz import TomlTz
 
 if sys.version_info < (3,):
     _range = xrange  # noqa: F821

--- a/toml/encoder.py
+++ b/toml/encoder.py
@@ -3,7 +3,7 @@ import re
 import sys
 from decimal import Decimal
 
-from toml.decoder import InlineTableDict
+from .decoder import InlineTableDict
 
 if sys.version_info >= (3,):
     unicode = str

--- a/toml/ordered.py
+++ b/toml/ordered.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
-from toml import TomlEncoder
-from toml import TomlDecoder
+from .encoder import TomlEncoder
+from .decoder import TomlDecoder
 
 
 class TomlOrderedDecoder(TomlDecoder):


### PR DESCRIPTION
Disambiguate internal imports by making them relative.

At the moment, if *toml* is embedded in a so-called *vendor* package that is part of a bigger project, the absolute import statements will reference the installed *toml* package, if any.