### PR TITLE
Raise an exception if EOF is reached and a string is unterminated

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -270,13 +270,3 @@ b-comment = "a is 3"
                    encoder=toml.TomlPreserveCommentEncoder())
 
     assert len(s) == len(test_str) and sorted(test_str) == sorted(s)
-
-
-@pytest.mark.parametrize('test_val', [
-    'opt = "unterminated double\n',
-    "opt = 'unterminated single\n",
-    "opt = '''\nunterminated\nraw multiline\n",
-    'opt = """\nunterminated\nmultiline\n'])
-def test_unterminated_string_eof(test_val):
-    with pytest.raises(toml.TomlDecodeError):
-        toml.loads(test_val)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -271,12 +271,12 @@ b-comment = "a is 3"
 
     assert len(s) == len(test_str) and sorted(test_str) == sorted(s)
 
+
 @pytest.mark.parametrize('test_val', [
     'opt = "unterminated double\n',
     "opt = 'unterminated single\n",
     "opt = '''\nunterminated\nraw multiline\n",
-    'opt = """\nunterminated\nmultiline\n',
-    ])
+    'opt = """\nunterminated\nmultiline\n'])
 def test_unterminated_string_eof(test_val):
     with pytest.raises(toml.TomlDecodeError):
         toml.loads(test_val)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -270,3 +270,13 @@ b-comment = "a is 3"
                    encoder=toml.TomlPreserveCommentEncoder())
 
     assert len(s) == len(test_str) and sorted(test_str) == sorted(s)
+
+@pytest.mark.parametrize('test_val', [
+    'opt = "unterminated double\n',
+    "opt = 'unterminated single\n",
+    "opt = '''\nunterminated\nraw multiline\n",
+    'opt = """\nunterminated\nmultiline\n',
+    ])
+def test_unterminated_string_eof(test_val):
+    with pytest.raises(toml.TomlDecodeError):
+        toml.loads(test_val)

--- a/toml/decoder.py
+++ b/toml/decoder.py
@@ -144,7 +144,7 @@ def load(f, _dict=dict, decoder=None):
         if decoder is None:
             decoder = TomlDecoder(_dict)
         d = decoder.get_empty_table()
-        for l in f:
+        for l in f:  # noqa: E741
             if op.exists(l):
                 d.update(load(l, _dict, decoder))
             else:

--- a/toml/decoder.py
+++ b/toml/decoder.py
@@ -358,6 +358,9 @@ def loads(s, _dict=dict, decoder=None):
     if keyname:
         raise TomlDecodeError("Key name found without value."
                               " Reached end of file.", original, len(s))
+    if openstring: # reached EOF and have an unterminated string
+        raise TomlDecodeError("Unterminated string found."
+                              " Reached end of file.", original, len(s))
     s = ''.join(sl)
     s = s.split('\n')
     multikey = None

--- a/toml/decoder.py
+++ b/toml/decoder.py
@@ -358,7 +358,7 @@ def loads(s, _dict=dict, decoder=None):
     if keyname:
         raise TomlDecodeError("Key name found without value."
                               " Reached end of file.", original, len(s))
-    if openstring: # reached EOF and have an unterminated string
+    if openstring:  # reached EOF and have an unterminated string
         raise TomlDecodeError("Unterminated string found."
                               " Reached end of file.", original, len(s))
     s = ''.join(sl)


### PR DESCRIPTION
Given a TOML file with an unterminated string value as the last option in the file
```toml
opt='''
this is a test
of an unfinished string
```
Current toml version (0.10.0) will simply not load that option instead of raising an Exception. The following test code returns an empty dict given the above toml file
```python
import toml
import pathlib

filepath = pathlib.Path('test.toml')
data = toml.loads(filepath.read_text())
assert bool(data)
```