### PR TITLE
Skip numpy tests when numpy is not available

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -103,7 +103,7 @@ def test_array_sep():
 
 
 def test_numpy_floats():
-    import numpy as np
+    np = pytest.importorskip('numpy')
 
     encoder = toml.TomlNumpyEncoder()
     d = {'a': np.array([1, .3], dtype=np.float64)}
@@ -120,7 +120,7 @@ def test_numpy_floats():
 
 
 def test_numpy_ints():
-    import numpy as np
+    np = pytest.importorskip('numpy')
 
     encoder = toml.TomlNumpyEncoder()
     d = {'a': np.array([1, 3], dtype=np.int64)}


### PR DESCRIPTION
Make it possible to successfully run tests without numpy installed.
This package is becoming quite hard profile, and being able to test it
without building numpy first would be a nice feature.