### PR TITLE
move outer_obj to prevent non uniqueness of ids

### DIFF
--- a/toml/encoder.py
+++ b/toml/encoder.py
@@ -59,9 +59,9 @@ def dumps(o, encoder=None):
         encoder = TomlEncoder(o.__class__)
     addtoretval, sections = encoder.dump_sections(o, "")
     retval += addtoretval
-    outer_objs = [id(o)]
     while sections:
         section_ids = [id(section) for section in sections]
+        outer_objs = [id(o)]
         for outer_obj in outer_objs:
             if outer_obj in section_ids:
                 raise ValueError("Circular reference detected")


### PR DESCRIPTION
In some unlucky cases, the circular reference detected exception is raised even though
it is not the case. This is a result of the fact that id() is only guaranteed to be unique for simultaneously existing objects.

see the id doc: 
"This is guaranteed to be unique among
    simultaneously existing objects. "

When new objects are created, such as is the case in the loop. This condition breaks down.
Moving outer_objs = [id(o)] inside the loop guarantees it continues to be unique.



Example of the issue:

```
import toml

some_dict = {'name': 'it0000_model_TrRadius_0.884678',
             'events': {'GCMT_event_MAURITIUS_-_REUNION_REGION_Mag_6.5_1995-9-17-17':
                            {'job_info':
                                 {'forward': {'name': '', 'submitted': False, 'retrieved': False, 'reposts': 0},
                                  'adjoint': {'name': '', 'submitted': False, 'retrieved': False, 'reposts': 0},
                                  'smoothing': {'name': '', 'submitted': False, 'retrieved': False, 'reposts': 0}},
                             'misfit': 0.0, 'usage_updated': False},
                        'GCMT_event_NORTHERN_MID-ATLANTIC_RIDGE_Mag_6.2_1994-1-25-7':
                            {'job_info': {'forward': {'name': '', 'submitted': False, 'retrieved': False, 'reposts': 0}, 'adjoint': {'name': '', 'submitted': False, 'retrieved': False, 'reposts': 0}, 'smoothing': {'name': '', 'submitted': False, 'retrieved': False, 'reposts': 0}}, 'misfit': 0.0, 'usage_updated': False}, 'GCMT_event_ROMANIA_Mag_6.9_1990-5-30-10': {'job_info': {'forward': {'name': '', 'submitted': False, 'retrieved': False, 'reposts': 0}, 'adjoint': {'name': '', 'submitted': False, 'retrieved': False, 'reposts': 0}, 'smoothing': {'name': '', 'submitted': False, 'retrieved': False, 'reposts': 0}}, 'misfit': 0.0, 'usage_updated': False}, 'GCMT_event_SOUTH_SANDWICH_ISLANDS_REGION_Mag_6.4_1993-5-2-11': {'job_info': {'forward': {'name': '', 'submitted': False, 'retrieved': False, 'reposts': 0}, 'adjoint': {'name': '', 'submitted': False, 'retrieved': False, 'reposts': 0}, 'smoothing': {'name': '', 'submitted': False, 'retrieved': False, 'reposts': 0}}, 'misfit': 0.0, 'usage_updated': False}}, 'last_control_group': ['GCMT_event_MAURITIUS_-_REUNION_REGION_Mag_6.5_1995-9-17-17', 'GCMT_event_NORTHERN_MID-ATLANTIC_RIDGE_Mag_6.2_1994-1-25-7'], 'new_control_group': []}


with open("bla.toml", "w") as fh:
    toml.dump(some_dict, fh)

```
raises:
```

Traceback (most recent call last):
  File "/Users/dirkphilip/Software/Inversionson_fork/create_event_mask.py", line 29, in <module>
    toml.dump(some_dict, fh)
  File "/Users/dirkphilip/miniconda3/envs/salvus/lib/python3.7/site-packages/toml/encoder.py", line 29, in dump
    d = dumps(o, encoder=encoder)
  File "/Users/dirkphilip/miniconda3/envs/salvus/lib/python3.7/site-packages/toml/encoder.py", line 67, in dumps
    raise ValueError("Circular reference detected")
ValueError: Circular reference detected
```