### PR TITLE
ids were based on the string, rather than the actual object which cau…

### DIFF
--- a/toml/encoder.py
+++ b/toml/encoder.py
@@ -61,7 +61,7 @@ def dumps(o, encoder=None):
     retval += addtoretval
     outer_objs = [id(o)]
     while sections:
-        section_ids = [id(section) for section in sections]
+        section_ids = [id(section) for section in sections.values()]
         for outer_obj in outer_objs:
             if outer_obj in section_ids:
                 raise ValueError("Circular reference detected")


### PR DESCRIPTION
In certain unlucky cases a circular reference was detected even though this was not actually the case.

For example the below code returned an exception for me:

`
import toml

some_dict = {'name': 'it0000_model_TrRadius_0.884678',
             'events': {'GCMT_event_MAURITIUS_-_REUNION_REGION_Mag_6.5_1995-9-17-17':
                       {'job_info':
                                 {'forward': {'name': '', 'submitted': False, 'retrieved': False, 'reposts': 0},
                                  'adjoint': {'name': '', 'submitted': False, 'retrieved': False, 'reposts': 0},
                                  'smoothing': {'name': '', 'submitted': False, 'retrieved': False, 'reposts': 0}},
                        'misfit': 0.0, 'usage_updated': False},
                        'GCMT_event_NORTHERN_MID-ATLANTIC_RIDGE_Mag_6.2_1994-1-25-7':
                        {'job_info':
                             {'forward': {'name': '', 'submitted': False, 'retrieved': False, 'reposts': 0},
                              'adjoint': {'name': '', 'submitted': False, 'retrieved': False, 'reposts': 0},
                              'smoothing': {'name': '', 'submitted': False, 'retrieved': False, 'reposts': 0}},
                         'misfit': 0.0, 'usage_updated': False},
                        'GCMT_event_ROMANIA_Mag_6.9_1990-5-30-10':
                        {'job_info':
                             {'forward': {'name': '', 'submitted': False, 'retrieved': False, 'reposts': 0},
                              'adjoint': {'name': '', 'submitted': False, 'retrieved': False, 'reposts': 0},
                              'smoothing': {'name': '', 'submitted': False, 'retrieved': False, 'reposts': 0}},
                         'misfit': 0.0, 'usage_updated': False},
                        'GCMT_event_SOUTH_SANDWICH_ISLANDS_REGION_Mag_6.4_1993-5-2-11':
                        {'job_info':
                             {'forward': {'name': '', 'submitted': False, 'retrieved': False, 'reposts': 0},
                              'adjoint': {'name': '', 'submitted': False, 'retrieved': False, 'reposts': 0},
                              'smoothing': {'name': '', 'submitted': False, 'retrieved': False, 'reposts': 0}},
                         'misfit': 0.0, 'usage_updated': False}},
             'last_control_group': ['GCMT_event_MAURITIUS_-_REUNION_REGION_Mag_6.5_1995-9-17-17',
                                    'GCMT_event_NORTHERN_MID-ATLANTIC_RIDGE_Mag_6.2_1994-1-25-7'],
             'new_control_group': []
             }

with open("bla.toml", "w") as fh:
    toml.dump(some_dict, fh)
`

This raised 

`
Traceback (most recent call last):
  File "/Users/dirkphilip/Software/Inversionson_fork/create_event_mask.py", line 48, in <module>
    toml.dump(some_dict, fh)
  File "/Users/dirkphilip/Software/toml/toml/encoder.py", line 29, in dump
    d = dumps(o, encoder=encoder)
  File "/Users/dirkphilip/Software/toml/toml/encoder.py", line 67, in dumps
    raise ValueError("Circular reference detected")
ValueError: Circular reference detected
`

By queuing the id from the object rather than the name of the descriptive string, this doesn't seem to happen anymore.