### PR TITLE
Fix #308: Add __deepcopy__ method to the `tz.TomlTz` class

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -271,3 +271,12 @@ b-comment = "a is 3"
                    encoder=toml.TomlPreserveCommentEncoder())
 
     assert len(s) == len(test_str) and sorted(test_str) == sorted(s)
+
+
+def test_deepcopy_timezone():
+    import copy
+
+    o = toml.loads("dob = 1979-05-24T07:32:00-08:00")
+    o2 = copy.deepcopy(o)
+    assert o2["dob"] == o["dob"]
+    assert o2["dob"] is not o["dob"]

--- a/toml/tz.py
+++ b/toml/tz.py
@@ -11,6 +11,9 @@ class TomlTz(tzinfo):
         self._hours = int(self._raw_offset[1:3])
         self._minutes = int(self._raw_offset[4:6])
 
+    def __deepcopy__(self, memo):
+        return self.__class__(self._raw_offset)
+
     def tzname(self, dt):
         return "UTC" + self._raw_offset
 


### PR DESCRIPTION
Without this method, the dict that results from parsing a datetime with a timezone cannot be deep-copied using the stdlib `copy.deepcopy()` function.

Example:

```python
import copy
import toml

o = toml.loads("dob = 1979-05-27T07:32:00-08:00")
# {'dob': datetime.datetime(1979, 5, 27, 7, 32, tzinfo=<toml.tz.TomlTz object at 0x7f4782efb3d0>)}
copy.deepcopy(o)
```

This currently raises a `TypeError`.
