### PR TITLE
show meaningful error message for wrong case booleans

### DIFF
--- a/toml/decoder.py
+++ b/toml/decoder.py
@@ -811,8 +811,12 @@ class TomlDecoder(object):
             raise ValueError("Empty value is invalid")
         if v == 'true':
             return (True, "bool")
+        elif v.lower() == 'true':
+            raise ValueError("Only all lowercase booleans allowed")
         elif v == 'false':
             return (False, "bool")
+        elif v.lower() == 'false':
+            raise ValueError("Only all lowercase booleans allowed")
         elif v[0] == '"' or v[0] == "'":
             quotechar = v[0]
             testv = v[1:].split(quotechar)


### PR DESCRIPTION
according to the spec booleans are all lowercase, when a capitalized boolean is used, the error message is not very informative ("This float doesn't have a leading digit")