### PR TITLE
Add official support for Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
  - "3.6"
  - "3.7"
  - "3.8"
+ - "3.9-dev"
  #- "pypy"
 
 notifications:

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, py36, py37, py38, pypy
+envlist = py27, py33, py34, py35, py36, py37, py38, py39, pypy
 
 [testenv]
 deps =


### PR DESCRIPTION
All tests pass for Python 3.9 without modifications to the source code. This commit adjusts the classifiers in `setup.py` and adds Python 3.9 to the tox and CI test environments.
