### PR TITLE
updated to use regex to split on commas in array literals (#322)

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -43,6 +43,12 @@ def test_bug_196():
     assert round_trip_bug_dict == bug_dict
     assert round_trip_bug_dict['x'] == bug_dict['x']
 
+def test_bug_322():
+    toml_string = """
+    a = [',', '']
+    """
+    decoded = toml.loads(toml_string)['a']
+    assert decoded == [',', '']
 
 def test_valid_tests():
     valid_dir = "toml-test/tests/valid/"

--- a/toml/decoder.py
+++ b/toml/decoder.py
@@ -936,6 +936,11 @@ class TomlDecoder(object):
             return True
         return False
 
+    def _split_array(self, a):
+        import re
+        PATTERN = re.compile(r'''((?:[^,"']|"[^"]*"|'[^']*')+)''')
+        return PATTERN.split(a)[1::2]
+
     def load_array(self, a):
         atype = None
         retval = []
@@ -943,7 +948,7 @@ class TomlDecoder(object):
         if '[' not in a[1:-1] or "" != a[1:-1].split('[')[0].strip():
             strarray = self._load_array_isstrarray(a)
             if not a[1:-1].strip().startswith('{'):
-                a = a[1:-1].split(',')
+                a = self._split_array(a[1:-1])
             else:
                 # a is an inline object, we must find the matching parenthesis
                 # to define groups


### PR DESCRIPTION
Per #322, updating as it was doing a raw `arr.split(",")` and ignoring if it was in a quote or not