### PR TITLE
Issue #285

### DIFF
--- a/toml/encoder.py
+++ b/toml/encoder.py
@@ -1,3 +1,4 @@
+import collections
 import datetime
 import re
 import sys
@@ -161,7 +162,7 @@ class TomlEncoder(object):
         https://github.com/toml-lang/toml#user-content-inline-table
         """
         retval = ""
-        if isinstance(section, dict):
+        if isinstance(section, collections.abc.Mapping):
             val_list = []
             for k, v in section.items():
                 val = self.dump_inline_table(v)


### PR DESCRIPTION
in dump_inline_table change the isinstance check to look for collections.abc.Mapping, not for dict. 

This enables UserDict and other classes that derive from collections.abc.Mapping, in addition to dict.