### PR TITLE
fix: py.typed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include LICENSE
 include README.rst
 include toml/*pyi
+include toml/py.typed
 include tox.ini
 include test.toml
 recursive-include tests *.py *.sh

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,7 @@ universal = True
 
 [metadata]
 license_file = LICENSE
+
+[options]
+zip_safe = False
+include_package_data = True


### PR DESCRIPTION
This package is missing a py.typed file, so downstream projects will not
show up in mypy or other type checkers, even though it has nice .pyi
files. This adds a the token file, which will cause mypy to pick it up
and use it. See [PEP 0561](https://www.python.org/dev/peps/pep-0561/).

It was also missing the .pyi files from the wheel (noticeable when running
`pip install build && python -m build`), added `include_package_data` to
fix that.

Edit: Actually I ran `pipx install build && pyproject-build`, but that's the same thing.

Closes #318 