### PR TITLE
Prettify list encoding

### DIFF
--- a/toml/encoder.py
+++ b/toml/encoder.py
@@ -148,10 +148,9 @@ class TomlEncoder(object):
         return self._dict()
 
     def dump_list(self, v):
-        retval = "["
-        for u in v:
-            retval += " " + unicode(self.dump_value(u)) + ","
-        retval += "]"
+        retval = "[ "
+        retval += ", ".join(unicode(self.dump_value(u)) for u in v)
+        retval += " ]"
         return retval
 
     def dump_inline_table(self, section):


### PR DESCRIPTION
More closely match official TOML examples for lists by excluding trailing commas. Also makes `dump_list` more Pythonic.

For example, the return value for
```print(toml.dumps({"data": [1, 2, 3, "abc"]}))```
that used to be
```data = [ 1, 2, 3, "abc",]```
will now be
```data = [ 1, 2, 3, "abc" ]```