### PR TITLE
Bug/uiri#310 hashtag in multiline string

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -44,6 +44,15 @@ def test_bug_196():
     assert round_trip_bug_dict['x'] == bug_dict['x']
 
 
+def test_bug_310():
+    multi_str = '''\
+  multi = """\
+  one "two #three" four
+"""
+'''
+    bug_dict = toml.loads(multi_str)
+    assert bug_dict["multi"] == 'one "two #three" four'
+
 def test_valid_tests():
     valid_dir = "toml-test/tests/valid/"
     for f in os.listdir(valid_dir):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -51,7 +51,8 @@ def test_bug_310():
 """
 '''
     bug_dict = toml.loads(multi_str)
-    assert bug_dict["multi"] == 'one "two #three" four'
+    assert bug_dict["multi"] == '  one "two #three" four\n'
+
 
 def test_valid_tests():
     valid_dir = "toml-test/tests/valid/"

--- a/toml/decoder.py
+++ b/toml/decoder.py
@@ -305,7 +305,7 @@ def loads(s, _dict=dict, decoder=None):
             else:
                 openstrchar = ""
         if item == '#' and (not openstring and not keygroup and
-                            not arrayoftables):
+                            not arrayoftables and not multilinestr):
             j = i
             comment = ""
             try:


### PR DESCRIPTION
Passes the toml-tests as well as the new unit test specific for this bug.
Closes #310 