### PR TITLE
Fix issue #364 and add a test for it

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -43,6 +43,10 @@ def test_bug_196():
     assert round_trip_bug_dict == bug_dict
     assert round_trip_bug_dict['x'] == bug_dict['x']
 
+def test_bug_364():
+    bug_dict = {"foo": [{"bar": {}, "moot": {"a": 1}}]}
+    round_trip_bug_dict = toml.loads(toml.dumps(bug_dict))
+    assert bug_dict == round_trip_bug_dict
 
 def test_valid_tests():
     valid_dir = "toml-test/tests/valid/"

--- a/toml/encoder.py
+++ b/toml/encoder.py
@@ -212,9 +212,9 @@ class TomlEncoder(object):
                                 s1, d1 = self.dump_sections(d[dsec], sup +
                                                             qsection + "." +
                                                             dsec)
+                                arraytabstr += ("[" + sup + qsection +
+                                                "." + dsec + "]\n")
                                 if s1:
-                                    arraytabstr += ("[" + sup + qsection +
-                                                    "." + dsec + "]\n")
                                     arraytabstr += s1
                                 for s1 in d1:
                                     newd[dsec + "." + s1] = d1[s1]


### PR DESCRIPTION
Array section headers should always be added to the TOML dump even on empty dicts in order to preserve values.