### PR TITLE
Add a link to LICENSE to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -221,4 +221,4 @@ Licensing
 =========
 
 This project is released under the terms of the MIT Open Source License. View
-*LICENSE.txt* for more information.
+`LICENSE <LICENSE>`_ for more information.


### PR DESCRIPTION
This commit adds a direct link to LICENSE to README (and corrects the filename), which, however, loses italic font style since inline format is necessary.