### PR TITLE
Support pickle for TomlTz. Fix #407

### DIFF
--- a/toml/tz.py
+++ b/toml/tz.py
@@ -11,6 +11,9 @@ class TomlTz(tzinfo):
         self._hours = int(self._raw_offset[1:3])
         self._minutes = int(self._raw_offset[4:6])
 
+    def __getinitargs__(self):
+        return (self._raw_offset,)
+
     def __deepcopy__(self, memo):
         return self.__class__(self._raw_offset)
 


### PR DESCRIPTION
Related to #407

In previous version, combining toml and pickle do not work. We can pickle them, but it cannot be loaded becauseTomlTz objects were not able to be pickled.
I made TomlTz picklable.

Procedure to reproduce the previous problem:
1. prepare a toml file including a datetime value with timezone
2. load the toml file by `toml.load()`
3. (do some editing)
4. update the toml file by `toml.dump()` and save as pickle
5. the toml file can be opened, but the pickled file could not be opened.