### PR TITLE
Add new encoder for dataclass

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -242,6 +242,33 @@ path = "/home/edgy"
         assert test_str == toml.dumps(o, encoder=toml.TomlPathlibEncoder())
 
 
+def test_dataclass():
+    if (3, 7) <= sys.version_info:
+        from dataclasses import dataclass, asdict
+
+        @dataclass
+        class TestDataClassIn():
+            a: int
+
+        @dataclass
+        class TestDataClass():
+            a: int
+            c: str
+            nested: TestDataClassIn
+            nested_arr: list
+
+        dc = TestDataClass(
+                a=1, c="ccc",
+                nested=TestDataClassIn(a=1),
+                nested_arr=[TestDataClassIn(a=10),
+                            TestDataClassIn(a=100)]
+             )
+        o = {"dc_on_root": dc, "dcarr_on_root": [TestDataClassIn(a=-1), TestDataClassIn(a=-2)]}
+        o_expected = {"dc_on_root": asdict(dc), "dcarr_on_root": [asdict(v) for v in o["dcarr_on_root"]]}
+
+        assert o_expected == toml.loads(toml.dumps(o, encoder=toml.TomlDataclassEncoder()))
+
+
 def test_comment_preserve_decoder_encoder():
     test_str = """[[products]]
 name = "Nail"

--- a/toml/__init__.py
+++ b/toml/__init__.py
@@ -23,3 +23,4 @@ TomlPreserveInlineDictEncoder = encoder.TomlPreserveInlineDictEncoder
 TomlNumpyEncoder = encoder.TomlNumpyEncoder
 TomlPreserveCommentEncoder = encoder.TomlPreserveCommentEncoder
 TomlPathlibEncoder = encoder.TomlPathlibEncoder
+TomlDataclassEncoder = encoder.TomlDataclassEncoder

--- a/toml/encoder.pyi
+++ b/toml/encoder.pyi
@@ -32,3 +32,6 @@ class TomlPreserveCommentEncoder(TomlEncoder):
 
 class TomlPathlibEncoder(TomlEncoder):
     def dump_value(self, v: Any): ...
+
+class TomlDataclassEncoder(TomlEncoder):
+    def dump_value(self, v: Any): ...

--- a/toml/tz.py
+++ b/toml/tz.py
@@ -11,6 +11,9 @@ class TomlTz(tzinfo):
         self._hours = int(self._raw_offset[1:3])
         self._minutes = int(self._raw_offset[4:6])
 
+    def __getinitargs__(self):
+        return (self._raw_offset,)
+
     def __deepcopy__(self, memo):
         return self.__class__(self._raw_offset)
 


### PR DESCRIPTION
Hi, thanks for the useful library.
I added a new encoder to handle dataclasses (`TomlDataclassEncoder`).

Note that `TomlDataclassEncoder` only converts contents into dicts, without dumping class names. Thus the dumped toml currently cannot be reconstructed fully, and objects that were dataclasses are loaded as dicts.
