### PR TITLE
Fixes #422. Currently this new test_bug_148 will be failed.  Think TDD.

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,9 +18,9 @@ TEST_DICT = {"a": {"b": 1, "c": 2}}
 
 
 def test_bug_148():
-    assert 'a = "\\u0064"\n' == toml.dumps({'a': '\\x64'})
-    assert 'a = "\\\\x64"\n' == toml.dumps({'a': '\\\\x64'})
-    assert 'a = "\\\\\\u0064"\n' == toml.dumps({'a': '\\\\\\x64'})
+    assert r'a = "\\x64"' + '\n' == toml.dumps({'a': r'\x64'})
+    assert r'a = "\\\\x64"' + '\n' == toml.dumps({'a': r'\\x64'})
+    assert r'a = "\\\\\\x64"' + '\n' == toml.dumps({'a': r'\\\x64'})
 
 
 def test_bug_144():


### PR DESCRIPTION
Note, this test is currently supposed to be failed by the current toml release.  The next PR I submit will create another version that will pass it.  The original test was incorrect, and has masked a bug.  Fixing that is the whole point of this and the next PR.  

Code containing a bug should fail a correctly written test designed to find it (such as this new test).

This PR changes the expected outputs on the LHSs to the same outputs from tomli-w and tomlkit.  This test function in its factory form has been tested against tomli-w, tomlkit and against the patched version I will shortly submit in my next PR.  It has also been tested in its inverse form (toml.loads on the LHS instead of toml.dumps on the RHS) against tomli, tomli-w, tomlkit, my patched version (toml_tools), against the Python 3.11 native tomllib, and against this libraries own toml.loads.  All pass.

Also changes normal string literals to raw string literals, to make it easier to count the number of back slashes in the input to actual, and in the expected result .

This test could be more extensive, e.g. to make sure r'\'*n + '\x64' -> r'\\'*n +'d'.  Great!  Lets write more tests!

Just lets do one thing and one thing only here - further tests deserve their own PRs.