### PR TITLE
Iterate over all files in toml-test/tests, including sub dirs

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -46,11 +46,13 @@ def test_bug_196():
 
 def test_valid_tests():
     valid_dir = "toml-test/tests/valid/"
-    for f in os.listdir(valid_dir):
-        if not f.endswith("toml"):
-            continue
-        with open(os.path.join(valid_dir, f)) as fh:
-            toml.dumps(toml.load(fh))
+    for path, sub_dirs, files in os.walk(valid_dir):
+        for name in files:
+            f = os.path.join(path, name)
+            if not f.endswith("toml"):
+                continue
+            with open(f) as fh:
+                toml.dumps(toml.load(fh))
 
 
 def test_circular_ref():
@@ -162,12 +164,14 @@ def test_decimal():
 
 def test_invalid_tests():
     invalid_dir = "toml-test/tests/invalid/"
-    for f in os.listdir(invalid_dir):
-        if not f.endswith("toml"):
-            continue
-        with pytest.raises(toml.TomlDecodeError):
-            with open(os.path.join(invalid_dir, f)) as fh:
-                toml.load(fh)
+    for path, sub_dirs, files in os.walk(invalid_dir):
+        for name in files:
+            f = os.path.join(path, name)
+            if not f.endswith("toml"):
+                continue
+            with pytest.raises(toml.TomlDecodeError):
+                with open(f) as fh:
+                    toml.load(fh)
 
 
 def test_exceptions():


### PR DESCRIPTION
Tests in toml-test have been moved into subdirectories (https://github.com/BurntSushi/toml-test/pull/80). Current unit tests ([test_valid_tests](https://github.com/uiri/toml/blob/5706d3155f4da8f3b84875f80bfe0dfc6565f61f/tests/test_api.py#L47), [test_invalid_tests](https://github.com/uiri/toml/blob/5706d3155f4da8f3b84875f80bfe0dfc6565f61f/tests/test_api.py#L163)) are unable to pick up toml files in subdirectories. 

This PR change will allow the unit tests to traverse the whole directory tree (`toml-test/tests/valid/` and `toml-test/tests/invalid/`), including sub directories.