### PR TITLE
Support subtypes of basic types when encoding

### DIFF
--- a/toml/encoder.py
+++ b/toml/encoder.py
@@ -173,7 +173,7 @@ class TomlEncoder(object):
 
     def dump_value(self, v):
         # Lookup function corresponding to v's type
-        dump_fn = self.dump_funcs.get(type(v))
+        dump_fn = next(f for t, f in self.dump_funcs.items() if isinstance(v, t), None)
         if dump_fn is None and hasattr(v, '__iter__'):
             dump_fn = self.dump_funcs[list]
         # Evaluate function (if it exists) else return v


### PR DESCRIPTION
The current implementation of `TomlEncoder` doesn't support subtypes of the supported basic types. For example:

```py
from enum import StrEnum
import toml

class ValidStrings(StrEnum):
    FOO = "foo"

assert isinstance(ValidStrings.FOO, str) # OK
data = {"foo": ValidStrings.FOO}
print(toml.dumps(data))
```

Output:
```
foo = [ "f", "o", "o",]
```

This pull request changes the implementation to use `isinstance` instead of `get(type(...))` to play nice with inheritence.

Fixes #418