### PR TITLE
Fix #430: list index out of range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/
+.pytest_cache
 
 # Translations
 *.mo
@@ -112,3 +113,6 @@ venv.bak/
 auto-save-list
 tramp
 .\#*
+
+# vscode
+.vscode

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,6 +17,12 @@ c = 2
 TEST_DICT = {"a": {"b": 1, "c": 2}}
 
 
+def test_bug_430():
+    # https://github.com/uiri/toml/issues/430 - IndexError
+    with pytest.raises(toml.TomlDecodeError, match="Key name found without value."):
+        toml.loads('\x00\r')
+
+
 def test_bug_148():
     assert 'a = "\\u0064"\n' == toml.dumps({'a': '\\x64'})
     assert 'a = "\\\\x64"\n' == toml.dumps({'a': '\\\\x64'})

--- a/toml/decoder.py
+++ b/toml/decoder.py
@@ -204,7 +204,7 @@ def loads(s, _dict=dict, decoder=None):
     line_no = 1
 
     for i, item in enumerate(sl):
-        if item == '\r' and sl[i + 1] == '\n':
+        if item == '\r' and len(sl) > (i + 1) and sl[i + 1] == '\n':
             sl[i] = ' '
             continue
         if keyname:

--- a/toml/encoder.py
+++ b/toml/encoder.py
@@ -173,7 +173,7 @@ class TomlEncoder(object):
 
     def dump_value(self, v):
         # Lookup function corresponding to v's type
-        dump_fn = next(f for t, f in self.dump_funcs.items() if isinstance(v, t), None)
+        dump_fn = next((f for t, f in self.dump_funcs.items() if isinstance(v, t)), None)
         if dump_fn is None and hasattr(v, '__iter__'):
             dump_fn = self.dump_funcs[list]
         # Evaluate function (if it exists) else return v


### PR DESCRIPTION
+ add parenthesis in encoder.py, because without them py3.10 did not want to run the code:
```
Generator expressions must be parenthesized if not sole argument
```