### PR TITLE
Treat "Z" offset in datetime as case-insensitive

### DIFF
--- a/toml/decoder.py
+++ b/toml/decoder.py
@@ -544,7 +544,7 @@ def _load_date(val):
                 microsecond = int(int(subsecondval) *
                                   (10 ** (6 - len(subsecondval))))
             else:
-                tz = TomlTz(val[19:])
+                tz = TomlTz(val[19:].upper())
     except ValueError:
         tz = None
     if "-" not in val[1:]:


### PR DESCRIPTION
This should be case-insensitive; e.g. this test failed:

	% toml-test ./tests/decoding_test.py -run valid/datetime/datetime
	FAIL valid/datetime/datetime
	     Key "lower" is not "datetime" but "datetime-local":
	       Expected:     map[string]any{"type":"datetime", "value":"1987-07-05T17:45:00Z"}
	       Your encoder: map[string]any{"type":"datetime-local", "value":"1987-07-05T17:45:00"}